### PR TITLE
Improve accessibility for VuiPopover

### DIFF
--- a/src/lib/components/popover/Popover.tsx
+++ b/src/lib/components/popover/Popover.tsx
@@ -43,6 +43,9 @@ export const VuiPopover = ({
   const [positionMarker, setPositionMarker] = useState<number>(0);
 
   const button = cloneElement(originalButton, {
+    'role': 'button',
+    'aria-haspopup': 'menu',
+    'aria-expanded': isOpen,
     isSelected: isOpen,
     onClick: () => {
       setIsOpen(!isOpen);

--- a/src/lib/components/popover/Popover.tsx
+++ b/src/lib/components/popover/Popover.tsx
@@ -43,9 +43,9 @@ export const VuiPopover = ({
   const [positionMarker, setPositionMarker] = useState<number>(0);
 
   const button = cloneElement(originalButton, {
-    'role': 'button',
-    'aria-haspopup': 'menu',
-    'aria-expanded': isOpen,
+    role: "button",
+    "aria-haspopup": "menu",
+    "aria-expanded": isOpen,
     isSelected: isOpen,
     onClick: () => {
       setIsOpen(!isOpen);


### PR DESCRIPTION
This PR adds move specificity for the screen reader for the Popover component. This also carries over to the SearchSelect component which uses Popover. 

I was not able to get the screen reader to read out the number of items in the Popover like the Select component though. I think this is something that could be done outside of VUI instead where we do something like this:
```js
        <VuiOptionsList
          isSelectable
          isScrollable
          onSelectOption={(value: string) => {
            setIsOpen(false);
            setSelectedOption(value);
          }}
          selected={selectedOption}
          options={options}
          aria-label={`List of tribes. ${options.length} items available.`}
        />
```

Before:
<img width="901" alt="Screenshot 2023-09-19 at 3 25 11 PM" src="https://github.com/vectara/vectara-ui/assets/29833473/922401b5-3141-4356-b5e5-349a14d006fa">

After:
<img width="714" alt="Screenshot 2023-09-19 at 3 25 42 PM" src="https://github.com/vectara/vectara-ui/assets/29833473/d2ec6af5-45ef-4b6b-b29f-be2a10eb18f9">
