### PR TITLE
Add VuiSuperRadioGroup.

### DIFF
--- a/src/docs/pages.tsx
+++ b/src/docs/pages.tsx
@@ -37,6 +37,7 @@ import { setting } from "./pages/setting";
 import { spacer } from "./pages/spacer";
 import { spinner } from "./pages/spinner";
 import { summary } from "./pages/summary";
+import { superRadioGroup } from "./pages/superRadioGroup";
 import { table } from "./pages/table";
 import { tabs } from "./pages/tabs";
 import { text } from "./pages/text";
@@ -74,7 +75,19 @@ export const categories: Category[] = [
   },
   {
     name: "Form",
-    pages: [validation, formGroup, setting, input, label, select, toggle, textArea, checkbox, radioButton]
+    pages: [
+      validation,
+      formGroup,
+      setting,
+      input,
+      label,
+      select,
+      toggle,
+      textArea,
+      checkbox,
+      radioButton,
+      superRadioGroup
+    ]
   },
   {
     name: "Controls",

--- a/src/docs/pages/radioButton/WithLabel.tsx
+++ b/src/docs/pages/radioButton/WithLabel.tsx
@@ -7,6 +7,7 @@ export const WithLabel = () => {
   return (
     <>
       <VuiRadioButton
+        groupName="radioButtonWithLabel"
         label="Pepperoni"
         onChange={() => setPizzaToppings("pepperoni")}
         checked={pizzaToppings === "pepperoni"}
@@ -15,6 +16,7 @@ export const WithLabel = () => {
       <VuiSpacer size="s" />
 
       <VuiRadioButton
+        groupName="radioButtonWithLabel"
         label="Mushrooms"
         onChange={() => setPizzaToppings("mushrooms")}
         checked={pizzaToppings === "mushrooms"}
@@ -23,6 +25,7 @@ export const WithLabel = () => {
       <VuiSpacer size="s" />
 
       <VuiRadioButton
+        groupName="radioButtonWithLabel"
         label="Jalapeños"
         onChange={() => setPizzaToppings("jalapenos")}
         checked={pizzaToppings === "jalapenos"}

--- a/src/docs/pages/superRadioGroup/LabelOnly.tsx
+++ b/src/docs/pages/superRadioGroup/LabelOnly.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+import { VuiSuperRadioGroup, RadioButtonConfig } from "../../../lib";
+
+export const LabelOnly = () => {
+  const [group, setGroup] = useState<RadioButtonConfig[]>([
+    {
+      label: "Pepperoni",
+      value: "pepperoni",
+      checked: true,
+      "data-testid": "pepperoni"
+    },
+    {
+      label: "Mushrooms",
+      value: "mushrooms",
+      checked: false,
+      "data-testid": "mushrooms"
+    },
+    {
+      label: "Jalapeños",
+      value: "jalapenos",
+      checked: false,
+      "data-testid": "jalapenos"
+    }
+  ]);
+
+  const onChange = (value: string) => {
+    setGroup(
+      group.map((item) => ({
+        ...item,
+        checked: item.value === value
+      }))
+    );
+  };
+
+  return <VuiSuperRadioGroup group={group} onChange={onChange} />;
+};

--- a/src/docs/pages/superRadioGroup/WithDescription.tsx
+++ b/src/docs/pages/superRadioGroup/WithDescription.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { VuiSuperRadioGroup, RadioButtonConfig } from "../../../lib";
+
+export const WithDescription = () => {
+  const [group, setGroup] = useState<RadioButtonConfig[]>([
+    {
+      label: "Pepperoni",
+      description: "The best pizza topping",
+      value: "pepperoni",
+      checked: true,
+      "data-testid": "pepperoni"
+    },
+    {
+      label: "Mushrooms",
+      description: "This one's for you if you're a fungi",
+      value: "mushrooms",
+      checked: false,
+      "data-testid": "mushrooms"
+    },
+    {
+      label: "Jalapeños",
+      description: "Muy caliente",
+      value: "jalapenos",
+      checked: false,
+      "data-testid": "jalapenos"
+    }
+  ]);
+
+  const onChange = (value: string) => {
+    setGroup(
+      group.map((item) => ({
+        ...item,
+        checked: item.value === value
+      }))
+    );
+  };
+
+  return <VuiSuperRadioGroup group={group} onChange={onChange} />;
+};

--- a/src/docs/pages/superRadioGroup/index.tsx
+++ b/src/docs/pages/superRadioGroup/index.tsx
@@ -1,0 +1,20 @@
+import { LabelOnly } from "./LabelOnly";
+import { WithDescription } from "./WithDescription";
+
+const LabelOnlySource = require("!!raw-loader!./LabelOnly");
+const WithDescriptionSource = require("!!raw-loader!./WithDescription");
+
+export const superRadioGroup = {
+  name: "Super radio group",
+  path: "/superRadioGroup",
+  examples: [
+    {
+      component: <LabelOnly />,
+      source: LabelOnlySource.default.toString()
+    },
+    {
+      component: <WithDescription />,
+      source: WithDescriptionSource.default.toString()
+    }
+  ]
+};

--- a/src/lib/components/form/_index.scss
+++ b/src/lib/components/form/_index.scss
@@ -3,4 +3,5 @@
 @import "label/index";
 @import "radioButton/index";
 @import "select/index";
+@import "superRadioGroup/index";
 @import "textArea/index";

--- a/src/lib/components/form/checkbox/Checkbox.tsx
+++ b/src/lib/components/form/checkbox/Checkbox.tsx
@@ -1,3 +1,4 @@
+import { createId } from "../../../utils/createId";
 import { VuiFlexContainer } from "../../flex/FlexContainer";
 import { VuiFlexItem } from "../../flex/FlexItem";
 
@@ -5,24 +6,14 @@ type Props = {
   checked: boolean;
   onChange: () => void;
   label?: string;
-  id?: string;
   disabled?: boolean;
 };
 
-export const VuiCheckbox = ({ checked, onChange, label, id, disabled, ...rest }: Props) => {
-  // Enable a lazy developer to just use the label as the ID,
-  // though this risks accidental duplication of IDs.
-  const idOrLabel = id ?? label;
+export const VuiCheckbox = ({ checked, onChange, label, disabled, ...rest }: Props) => {
+  const id = createId();
 
   const checkbox = (
-    <input
-      id={label ? idOrLabel : undefined}
-      type="checkbox"
-      checked={checked}
-      onChange={onChange}
-      disabled={disabled}
-      {...rest}
-    />
+    <input id={id} type="checkbox" checked={checked} onChange={onChange} disabled={disabled} {...rest} />
   );
 
   if (!label) {
@@ -36,7 +27,7 @@ export const VuiCheckbox = ({ checked, onChange, label, id, disabled, ...rest }:
       </VuiFlexItem>
 
       <VuiFlexItem grow={false} shrink={false}>
-        <label className="vuiCheckboxLabel" htmlFor={idOrLabel}>
+        <label className="vuiCheckboxLabel" htmlFor={id}>
           {label}
         </label>
       </VuiFlexItem>

--- a/src/lib/components/form/index.ts
+++ b/src/lib/components/form/index.ts
@@ -3,5 +3,8 @@ export { VuiLabel } from "./label/Label";
 export { VuiNumberInput } from "./input/NumberInput";
 export { VuiRadioButton } from "./radioButton/RadioButton";
 export { VuiSelect } from "./select/Select";
+export { VuiSuperRadioGroup } from "./superRadioGroup/SuperRadioGroup";
 export { VuiTextInput } from "./input/TextInput";
 export { VuiTextArea } from "./textArea/TextArea";
+
+export type { RadioButtonConfig } from "./superRadioGroup/types";

--- a/src/lib/components/form/radioButton/RadioButton.tsx
+++ b/src/lib/components/form/radioButton/RadioButton.tsx
@@ -1,42 +1,34 @@
+import { createId } from "../../../utils/createId";
 import { VuiFlexContainer } from "../../flex/FlexContainer";
 import { VuiFlexItem } from "../../flex/FlexItem";
 
 type Props = {
   checked: boolean;
   onChange: () => void;
+  groupName: string;
   label?: string;
-  id?: string;
   disabled?: boolean;
 };
 
-export const VuiRadioButton = ({ checked, onChange, label, id, disabled, ...rest }: Props) => {
-  // Enable a lazy developer to just use the label as the ID,
-  // though this risks accidental duplication of IDs.
-  const idOrLabel = id ?? label;
+export const VuiRadioButton = ({ checked, onChange, label, groupName, disabled, ...rest }: Props) => {
+  const id = createId();
 
-  const checkbox = (
-    <input
-      id={label ? idOrLabel : undefined}
-      type="radio"
-      checked={checked}
-      onChange={onChange}
-      disabled={disabled}
-      {...rest}
-    />
+  const radioButton = (
+    <input id={id} type="radio" checked={checked} onChange={onChange} disabled={disabled} {...rest} />
   );
 
   if (!label) {
-    return checkbox;
+    return radioButton;
   }
 
   return (
     <VuiFlexContainer spacing="xs" alignItems="center">
       <VuiFlexItem grow={false} shrink={false}>
-        {checkbox}
+        {radioButton}
       </VuiFlexItem>
 
       <VuiFlexItem grow={false} shrink={false}>
-        <label className="vuiRadioButtonLabel" htmlFor={idOrLabel}>
+        <label className="vuiRadioButtonLabel" htmlFor={id}>
           {label}
         </label>
       </VuiFlexItem>

--- a/src/lib/components/form/superRadioGroup/SuperRadioButton.tsx
+++ b/src/lib/components/form/superRadioGroup/SuperRadioButton.tsx
@@ -1,0 +1,44 @@
+import { createId } from "../../../utils/createId";
+import { VuiFlexContainer } from "../../flex/FlexContainer";
+import { VuiFlexItem } from "../../flex/FlexItem";
+import { VuiSpacer } from "../../spacer/Spacer";
+import { VuiText } from "../../typography/Text";
+import { VuiTextColor } from "../../typography/TextColor";
+import { RadioButtonConfig } from "./types";
+
+type Props = RadioButtonConfig & {
+  groupName: string;
+  onChange: (value: string) => void;
+};
+
+export const VuiSuperRadioButton = ({ label, description, value, checked, onChange, groupName, ...rest }: Props) => {
+  const id = createId();
+
+  return (
+    <label className="vuiSuperRadioButton" htmlFor={id}>
+      <VuiFlexContainer spacing="l" alignItems="center">
+        <VuiFlexItem grow={false} shrink={false}>
+          <input id={id} name={groupName} type="radio" checked={checked} onChange={() => onChange(value)} {...rest} />
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false} shrink={false}>
+          <VuiText>
+            <p>{label}</p>
+          </VuiText>
+
+          {description && (
+            <>
+              <VuiSpacer size="xxs" />
+
+              <VuiText size="xs">
+                <VuiTextColor color="subdued">
+                  <p>{description}</p>
+                </VuiTextColor>
+              </VuiText>
+            </>
+          )}
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    </label>
+  );
+};

--- a/src/lib/components/form/superRadioGroup/SuperRadioGroup.tsx
+++ b/src/lib/components/form/superRadioGroup/SuperRadioGroup.tsx
@@ -1,0 +1,20 @@
+import { createId } from "../../../utils/createId";
+import { VuiSuperRadioButton } from "./SuperRadioButton";
+import { RadioButtonConfig } from "./types";
+
+type Props = {
+  group: RadioButtonConfig[];
+  onChange: (value: string) => void;
+};
+
+export const VuiSuperRadioGroup = ({ group, onChange }: Props) => {
+  const groupName = createId();
+
+  return (
+    <div className="vuiSuperRadioGroup">
+      {group.map((item) => (
+        <VuiSuperRadioButton key={item.value} {...item} groupName={groupName} onChange={onChange} />
+      ))}
+    </div>
+  );
+};

--- a/src/lib/components/form/superRadioGroup/_index.scss
+++ b/src/lib/components/form/superRadioGroup/_index.scss
@@ -1,0 +1,26 @@
+.vuiSuperRadioGroup {
+  border: 1px solid $borderColor;
+  border-radius: $sizeXs;
+}
+
+.vuiSuperRadioButton + .vuiSuperRadioButton {
+  border-top: 1px solid $borderColor;
+}
+
+.vuiSuperRadioButton {
+  display: block;
+  width: 100%;
+  padding: $sizeS $sizeL;
+  cursor: pointer;
+  text-decoration: none;
+  box-shadow: $shadowSmallStart;
+  transition: all $transitionSpeed;
+  text-decoration-color: $colorText;
+  text-align: left;
+
+  &:hover {
+    box-shadow: $shadowSmallEnd;
+    text-decoration: underline;
+    text-decoration-color: $colorText;
+  }
+}

--- a/src/lib/components/form/superRadioGroup/types.ts
+++ b/src/lib/components/form/superRadioGroup/types.ts
@@ -1,0 +1,8 @@
+export type RadioButtonConfig = {
+  label: React.ReactNode;
+  description?: React.ReactNode;
+  value: string;
+  checked: boolean;
+  disabled?: boolean;
+  "data-testid"?: string;
+};

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -23,7 +23,17 @@ import { VuiCopyButton } from "./copyButton/CopyButton";
 import { VuiDrawer } from "./drawer/Drawer";
 import { VuiFlexContainer } from "./flex/FlexContainer";
 import { VuiFlexItem } from "./flex/FlexItem";
-import { VuiCheckbox, VuiLabel, VuiNumberInput, VuiRadioButton, VuiSelect, VuiTextInput, VuiTextArea } from "./form";
+import {
+  RadioButtonConfig,
+  VuiCheckbox,
+  VuiLabel,
+  VuiNumberInput,
+  VuiRadioButton,
+  VuiSelect,
+  VuiSuperRadioGroup,
+  VuiTextInput,
+  VuiTextArea
+} from "./form";
 import { VuiFormGroup } from "./formGroup/FormGroup";
 import { VuiHorizontalRule } from "./horizontalRule/HorizontalRule";
 import { VuiIcon } from "./icon/Icon";
@@ -78,10 +88,11 @@ export type {
   InfoTableRowType,
   Notification,
   OptionListItem,
-  TabSize,
+  RadioButtonConfig,
   SearchResult,
   Sections,
   SectionItem,
+  TabSize,
   Tree,
   TreeItem
 };
@@ -151,6 +162,7 @@ export {
   VuiSpacer,
   VuiSpinner,
   VuiSummary,
+  VuiSuperRadioGroup,
   VuiTable,
   VuiTab,
   VuiTabbedRoutes,


### PR DESCRIPTION
Breaking changes:
* Removed `id` prop from VuiCheckbox and VuiRadioButton.
* Added required `groupName` prop to VuiRadioButton. This is an accessibility improvement.

![image](https://github.com/vectara/vectara-ui/assets/1238659/6c5e4420-5140-48fa-83bd-7223cf6870c5)
