### PR TITLE
Add VuiGrid.

### DIFF
--- a/src/docs/pages.tsx
+++ b/src/docs/pages.tsx
@@ -13,6 +13,7 @@ import { copyButton } from "./pages/copyButton";
 import { drawer } from "./pages/drawer";
 import { flex } from "./pages/flex";
 import { formGroup } from "./pages/formGroup";
+import { grid } from "./pages/grid";
 import { horizontalRule } from "./pages/horizontalRule";
 import { icon } from "./pages/icon";
 import { infoTable } from "./pages/infoTable";
@@ -68,7 +69,7 @@ export const categories: Category[] = [
   },
   {
     name: "Layout",
-    pages: [tabs, accordion, popover, flex, spacer, card, horizontalRule]
+    pages: [tabs, accordion, popover, flex, grid, spacer, card, horizontalRule]
   },
   {
     name: "Content",

--- a/src/docs/pages/grid/Grid.tsx
+++ b/src/docs/pages/grid/Grid.tsx
@@ -1,0 +1,23 @@
+import { VuiGrid, VuiTopicButton, VuiText } from "../../../lib";
+
+export const Grid = () => (
+  <VuiGrid columns={3}>
+    <VuiTopicButton href="https://docs.vectara.com" title="Read the docs">
+      <VuiText>
+        <p>They're full of delicious knowledge!</p>
+      </VuiText>
+    </VuiTopicButton>
+
+    <VuiTopicButton href="https://www.vectara.com" title="Check out our thoughtful blog posts">
+      <VuiText>
+        <p>We share the things we've built and learned in this excited GenAI space.</p>
+      </VuiText>
+    </VuiTopicButton>
+
+    <VuiTopicButton href="https://vectara.github.io/vectara-ui/" title="Bask in VUI">
+      <VuiText>
+        <p>You're already doing it!</p>
+      </VuiText>
+    </VuiTopicButton>
+  </VuiGrid>
+);

--- a/src/docs/pages/grid/index.tsx
+++ b/src/docs/pages/grid/index.tsx
@@ -1,0 +1,13 @@
+import { Grid } from "./Grid";
+const GridSource = require("!!raw-loader!./Grid");
+
+export const grid = {
+  name: "Grid",
+  path: "/grid",
+  examples: [
+    {
+      component: <Grid />,
+      source: GridSource.default.toString()
+    }
+  ]
+};

--- a/src/lib/components/_index.scss
+++ b/src/lib/components/_index.scss
@@ -11,6 +11,7 @@
 @import "drawer/index";
 @import "flex/index";
 @import "form/index";
+@import "grid/index";
 @import "horizontalRule/index";
 @import "icon/index";
 @import "infoTable/index";

--- a/src/lib/components/grid/Grid.tsx
+++ b/src/lib/components/grid/Grid.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import classNames from "classnames";
+import { FlexSpacing } from "../flex/types";
+
+export const COLUMNS = [1, 2, 3] as const;
+export type Columns = (typeof COLUMNS)[number];
+
+type Props = {
+  children?: React.ReactNode;
+  columns?: Columns;
+  spacing?: FlexSpacing;
+};
+
+export const VuiGrid = ({ children, columns = 2, spacing = "m", ...rest }: Props) => {
+  const classes = classNames("vuiGrid", `vuiGrid--${spacing}`, `vuiGrid--columns${columns}`);
+
+  return (
+    <div className="vuiGridContainer" {...rest}>
+      <div className={classes}>{children}</div>
+    </div>
+  );
+};

--- a/src/lib/components/grid/_index.scss
+++ b/src/lib/components/grid/_index.scss
@@ -1,0 +1,50 @@
+.vuiGridContainer {
+  container-type: inline-size;
+}
+
+.vuiGrid {
+  display: grid;
+}
+
+// spacing
+$spacing: (
+  xss: $sizeXxs,
+  xs: $sizeXs,
+  s: $sizeS,
+  m: $sizeM,
+  l: $sizeL,
+  xl: $sizeXl,
+  xxl: $sizeXxl
+);
+
+@each $spacingName, $spacingValue in $spacing {
+  .vuiGrid--#{$spacingName} {
+    column-gap: $spacingValue;
+    row-gap: $spacingValue;
+  }
+}
+
+.vuiGrid--columns1 {
+  grid-template-columns: 1fr;
+}
+
+.vuiGrid--columns2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+.vuiGrid--columns3 {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+@container (width < 800px) {
+  .vuiGrid--columns3 {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@container (width < 500px) {
+  .vuiGrid--columns2,
+  .vuiGrid--columns3 {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -35,6 +35,7 @@ import {
   VuiTextArea
 } from "./form";
 import { VuiFormGroup } from "./formGroup/FormGroup";
+import { VuiGrid } from "./grid/Grid";
 import { VuiHorizontalRule } from "./horizontalRule/HorizontalRule";
 import { VuiIcon } from "./icon/Icon";
 import { ICON_COLOR, ICON_SIZE } from "./icon/types";
@@ -135,6 +136,7 @@ export {
   VuiFlexContainer,
   VuiFlexItem,
   VuiFormGroup,
+  VuiGrid,
   VuiHorizontalRule,
   VuiIcon,
   VuiInfoTable,


### PR DESCRIPTION
This component collapses to fewer columns as the container width gets narrower.

![image](https://github.com/vectara/vectara-ui/assets/1238659/488a0e33-c9f1-461a-ad16-5a35e99b4b18)

![image](https://github.com/vectara/vectara-ui/assets/1238659/cb19c591-b0a0-4c60-b27d-78b8a70db00d)

![image](https://github.com/vectara/vectara-ui/assets/1238659/fe1a9cab-ddda-4b28-a4c0-b0df499896b9)
