### PR TITLE
Fix getTrackingProps incompatibility with React's casing expectations.

### DIFF
--- a/src/lib/components/badge/Badge.tsx
+++ b/src/lib/components/badge/Badge.tsx
@@ -31,6 +31,7 @@ export const VuiBadge = ({ children, className, color, onClick, href, target, tr
 
   if (href) {
     return (
+      // @ts-expect-error Type 'string' is not assignable to type 'HTMLAttributeReferrerPolicy | undefined'.
       <Link className={classes} onClick={onClick} to={href} target={target} {...getTrackingProps(track)}>
         {children}
       </Link>

--- a/src/lib/components/button/BaseButton.tsx
+++ b/src/lib/components/button/BaseButton.tsx
@@ -81,6 +81,7 @@ export const BaseButton = forwardRef<HTMLButtonElement | null, Props>(
       });
 
       return (
+        // @ts-expect-error Type 'string' is not assignable to type 'HTMLAttributeReferrerPolicy | undefined'.
         <Link
           className={wrapperClasses}
           to={href}

--- a/src/lib/components/button/IconButton.tsx
+++ b/src/lib/components/button/IconButton.tsx
@@ -31,6 +31,7 @@ export const VuiIconButton = forwardRef<HTMLButtonElement | null, Props>(
 
     if (href) {
       return (
+        // @ts-expect-error Type 'string' is not assignable to type 'HTMLAttributeReferrerPolicy | undefined'.
         <Link to={href} target={target} {...props} {...getTrackingProps(track)}>
           <button ref={ref}>{buttonIcon}</button>
         </Link>

--- a/src/lib/components/summary/Summary.tsx
+++ b/src/lib/components/summary/Summary.tsx
@@ -6,7 +6,7 @@ import { VuiText } from "../typography/Text";
 const markDownCitations = (summary: string) => {
   const citations = extractCitations(summary);
   return citations
-    .reduce((accum, { text, references }, index) => {
+    .reduce((accum, { text, references }) => {
       if (references) {
         accum.push(text);
 

--- a/src/lib/utils/getTrackingProps.ts
+++ b/src/lib/utils/getTrackingProps.ts
@@ -3,8 +3,11 @@ export const getTrackingProps = (track?: boolean) => {
     return {
       // Protect against tabnabbing.
       rel: "noopener",
-      // Provide information for tracking, e.g. to docs.
-      referrerpolicy: "no-referrer-when-downgrade"
+      // Provide information for tracking, e.g. to docs. Technically this should be
+      // 'referrerpolicy' but React wants it in camel case. This clashes with
+      // react-router Link's HTMLAttributeReferrerPolicy type definition so we
+      // have to use @ts-expect-error at callsites that consume this helper.
+      referrerPolicy: "no-referrer-when-downgrade"
     };
   }
   // Protect against tabnabbing and strip information from the referrer header.


### PR DESCRIPTION
We use the `getTrackingProps` helper to generate attributes that will be applied to anchor tags. One of these attributes is  [`referrerpolicy`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#referrerpolicy). React throws an error because it expects this to be camel-cased as `referrerPolicy`. However, when this attribute is provided to a React-Router Link component, TypeScript complains because this component's type definition uses `HTMLAttributeReferrerPolicy`, which expects the spec casing of `referrerpolicy`.

The solution is to use the casing that's compatible with React and ignore the TS errors.