### PR TITLE
Uncouple step progress from step state. Fix current step icon color.

### DIFF
--- a/src/docs/pages/steps/InteractiveSteps.tsx
+++ b/src/docs/pages/steps/InteractiveSteps.tsx
@@ -4,8 +4,11 @@ import { VuiSteps, VuiStepProps, StepStatus } from "../../../lib";
 export const InteractiveSteps = () => {
   const [currentStep, setCurrentStep] = useState(1);
 
-  const getStepStatus = (stepIndex: number): StepStatus => {
-    if (currentStep > stepIndex) return "complete";
+  const getStepStatus = (
+    stepIndex: number,
+    completeState: "complete" | "current" | "warning" | "danger"
+  ): StepStatus => {
+    if (currentStep > stepIndex) return completeState;
     if (currentStep === stepIndex) return "current";
     return "incomplete";
   };
@@ -13,25 +16,25 @@ export const InteractiveSteps = () => {
   const dynamicSteps: VuiStepProps[] = [
     {
       title: "Account Setup",
-      status: getStepStatus(0),
+      status: getStepStatus(0, "danger"),
       subTitle: "Create your account",
       onClick: () => setCurrentStep(0)
     },
     {
       title: "Profile Information",
-      status: getStepStatus(1),
+      status: getStepStatus(1, "complete"),
       subTitle: "Add your details",
       onClick: () => setCurrentStep(1)
     },
     {
       title: "Verification",
-      status: getStepStatus(2),
+      status: getStepStatus(2, "danger"),
       subTitle: "Verify your email",
       onClick: () => setCurrentStep(2)
     },
     {
       title: "Complete",
-      status: getStepStatus(3),
+      status: getStepStatus(3, "complete"),
       subTitle: "Finish setup",
       onClick: () => setCurrentStep(3)
     }

--- a/src/lib/components/steps/Steps.tsx
+++ b/src/lib/components/steps/Steps.tsx
@@ -10,8 +10,8 @@ export type { VuiStepProps, StepSize, StepStatus };
 
 const statusToColor: Record<StepStatus, (typeof ICON_COLOR)[number]> = {
   complete: "success",
-  current: "neutral",
-  incomplete: "neutral",
+  current: "primary",
+  incomplete: "subdued",
   disabled: "neutral",
   warning: "warning",
   danger: "danger",
@@ -30,6 +30,8 @@ export const VuiSteps = ({ steps, className, size = "s", ...rest }: Props) => {
   });
 
   const totalSteps = steps.length;
+
+  const currentStepIndex = steps.findIndex((step) => step.status === "current");
 
   return (
     <div className={classes} {...rest}>
@@ -57,7 +59,7 @@ export const VuiSteps = ({ steps, className, size = "s", ...rest }: Props) => {
               {!isLastStep && (
                 <div
                   className={classNames("vuiSteps__connector", {
-                    "vuiSteps__connector--complete": step.status === "complete"
+                    "vuiSteps__connector--complete": index < currentStepIndex
                   })}
                 />
               )}
@@ -72,7 +74,7 @@ export const VuiSteps = ({ steps, className, size = "s", ...rest }: Props) => {
                       <VuiSpinner />
                     </div>
                   ) : icon ? (
-                    <VuiIcon color={statusToColor[step.status ?? "complete"]} size={size === "xs" ? undefined : size}>
+                    <VuiIcon color={statusToColor[step.status ?? "incomplete"]} size={size === "xs" ? undefined : size}>
                       {icon}
                     </VuiIcon>
                   ) : size === "xs" ? null : (


### PR DESCRIPTION
## Overview

The connector state should reflect the user's progress through the steps, regardless of whether steps contain errors or not. The user can look at the state of the step itself to see whether it has errors.

## Screenshots

### Before

<img width="1388" height="172" alt="image" src="https://github.com/user-attachments/assets/6cb55045-8b10-4943-9f47-c5954be8e515" />

### After

<img width="2140" height="170" alt="image" src="https://github.com/user-attachments/assets/352bb04b-f1a8-48a5-a7d9-65db99974d26" />

<img width="1978" height="226" alt="image" src="https://github.com/user-attachments/assets/064eed67-0bb4-456c-a177-59a41f4f725c" />
