### PR TITLE
Add code support to notification component

### DIFF
--- a/src/docs/pages/notifications/Notifications.tsx
+++ b/src/docs/pages/notifications/Notifications.tsx
@@ -19,6 +19,17 @@ const getNotification = () => {
       message: "Not good. Very bad. Potentially catastrophic. You should probably do something about this.",
       hasCopyButton: true,
       children: <VuiButtonPrimary color="danger">Vent atmosphere</VuiButtonPrimary>
+    },
+    {
+      color: "danger",
+      message: "API request failed with error:",
+      code: {
+        content: `fetch('/api/data')
+  .then(response => response.json())
+  .catch(error => console.error(error))`,
+        language: "js"
+      },
+      hasCopyButton: true
     }
   ] as const;
 

--- a/src/lib/components/notification/Notification.tsx
+++ b/src/lib/components/notification/Notification.tsx
@@ -9,6 +9,8 @@ import { VuiIconButton } from "../button/IconButton";
 import { VuiIcon } from "../icon/Icon";
 import { VuiSpacer } from "../spacer/Spacer";
 import { VuiCopyButton } from "../copyButton/CopyButton";
+import { VuiCode } from "../code/Code";
+import { CodeLanguage } from "../code/types";
 
 export const addNotification = (props: Omit<Props, "onDismiss">) => {
   return sonnerToast.custom(
@@ -30,9 +32,13 @@ type Props = {
   onDismiss: () => void;
   children?: React.ReactNode;
   hasCopyButton?: boolean;
+  code?: {
+    content: string;
+    language?: CodeLanguage;
+  };
 };
 
-export const VuiNotification = ({ color, message, onDismiss, children, hasCopyButton }: Props) => {
+export const VuiNotification = ({ color, message, onDismiss, children, hasCopyButton, code }: Props) => {
   const classes = classNames("vuiNotification", `vuiNotification--${color}`);
 
   let icon;
@@ -86,7 +92,14 @@ export const VuiNotification = ({ color, message, onDismiss, children, hasCopyBu
                 <VuiTextColor color={color}>{message}</VuiTextColor>
               </VuiText>
 
-              {hasCopyButton && (
+              {code && (
+                <>
+                  <VuiSpacer size="s" />
+                  <VuiCode language={code.language}>{code.content}</VuiCode>
+                </>
+              )}
+
+              {hasCopyButton && !code && (
                 <>
                   <VuiSpacer size="s" />
                   <VuiCopyButton value={message} size="s" label="Copy" />


### PR DESCRIPTION
## Summary
- Add optional `code` prop to VuiNotification component for displaying syntax-highlighted code blocks
- Support all CodeLanguage types from existing code component  
- Disable copy button when code is present (code component handles its own copy functionality)
- Update documentation with example showing JavaScript code in notification

## Screenshot
<img width="1026" height="514" alt="CleanShot 2025-08-25 at 22 19 35@2x" src="https://github.com/user-attachments/assets/3183b783-525a-4b5b-9170-f53f9ffc38c3" />

🤖 Generated with [Claude Code](https://claude.ai/code)