### PR TITLE
Refine text styles for Markdown content. Add support for blockquote, hr, table, sup, and pre and code blocks.

### DIFF
--- a/src/docs/pages/text/Text.tsx
+++ b/src/docs/pages/text/Text.tsx
@@ -18,9 +18,19 @@ export const Text = () => (
             <h6>Heading 6</h6>
             <p>
               Paragraph with some <strong>bold</strong> and <em>emphasized</em> words in it. Let's make this really,
-              really, really, super-duper, ridiculously long just so we can be sure the text wraps and you can get idea
-              of the line-height.
+              really, really, super-duper, <code>ridiculously long</code> just so we can be sure the text wraps and you
+              can get idea of the line-height.<sup>5</sup>
             </p>
+
+            <blockquote>
+              <p>
+                A long paragraph of text that's inside a blockquote. This is to demonstrate how blockquotes look when
+                used in conjunction with the VuiText component. The quick brown fox jumps over the lazy dog. The quick
+                brown fox jumps over the lazy dog.
+              </p>
+            </blockquote>
+
+            <hr />
 
             <p>
               Here's another paragraph with a <a href="#">link</a> in it.
@@ -41,8 +51,39 @@ export const Text = () => (
             </ol>
 
             <p>
-              <code>doc.title='Vectara'</code>
+              <code>(code) doc.title='Vectara'</code>
             </p>
+
+            <p>
+              <pre>(pre) doc.title='Vectara'</pre>
+            </p>
+
+            <table>
+              <thead>
+                <tr>
+                  <th> Line </th>
+                  <th> Entry </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td> 1 </td>
+                  <td> A gull of memory crosses low, backlit and slow. </td>
+                </tr>
+                <tr>
+                  <td> 2 </td>
+                  <td> Quiet interest gathers on a breath I did not spend. </td>
+                </tr>
+                <tr>
+                  <td> 3 </td>
+                  <td> Moon counts the hours like coins within a tray. </td>
+                </tr>
+                <tr>
+                  <td> 4 </td>
+                  <td> I sign in trembling script: return by day. </td>
+                </tr>
+              </tbody>
+            </table>
           </VuiText>
 
           <VuiSpacer size="m" />

--- a/src/lib/components/typography/_text.scss
+++ b/src/lib/components/typography/_text.scss
@@ -1,5 +1,7 @@
 @use "sass:map";
 
+$textRhythm: $sizeM;
+
 .vuiText {
   overflow-wrap: break-word;
   word-break: break-word;
@@ -24,22 +26,47 @@
   ul,
   ol {
     margin-left: $sizeM;
-    margin-bottom: $sizeXs;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
+    margin-bottom: $textRhythm;
   }
 
+  hr {
+    border-top: none;
+    border-left: none;
+    border-right: none;
+    border-bottom: 1px solid;
+    width: 100%;
+    border-bottom-color: $borderColor;
+    margin-bottom: $textRhythm;
+  }
+
+  pre,
   code {
     border: 1px solid $borderColorLight;
     padding: $sizeXxxs $sizeXs;
+  }
+
+  pre:only-child,
+  code:only-child {
+    padding: $sizeXs $sizeS;
+    border: none;
+    border-radius: $sizeXs;
+    overflow: auto;
+    background-color: $colorLightShade;
+    margin-bottom: $textRhythm;
+  }
+
+  blockquote {
+    border-left: 4px solid $colorLightShade;
+    padding-left: $sizeM;
+    color: $colorDarkerShade;
+    margin-bottom: $textRhythm;
   }
 
   table {
     width: 100%;
     table-layout: fixed;
     border: 1px solid $borderColorLight;
+    margin-bottom: $textRhythm;
 
     thead {
       background-color: $colorLightShade;
@@ -63,6 +90,10 @@
       padding: $sizeS $sizeS;
     }
   }
+
+  sup {
+    vertical-align: super;
+  }
 }
 
 .vuiText--truncate {
@@ -79,40 +110,50 @@
   ol {
     font-size: $fontSize;
     line-height: 1.4;
-    margin-bottom: $sizeXs;
     font-weight: $fontWeight;
-
-    &:last-child {
-      margin-bottom: 0;
-    }
+    margin-bottom: $textRhythm;
   }
 
   h1 {
     font-size: $fontSize * 2;
     line-height: 1.1;
     font-weight: $fontWeightStrong;
-    margin-bottom: $sizeXs;
+    margin-bottom: $textRhythm;
   }
 
   h2 {
     font-size: $fontSize * 1.5;
     line-height: 1.2;
     font-weight: $fontWeightNormal;
-    margin-bottom: $sizeXs;
+    margin-bottom: $textRhythm;
   }
 
   h3 {
     font-size: $fontSize * 1.25;
     line-height: 1.3;
     font-weight: $fontWeightNormal;
-    margin-bottom: $sizeXs;
+    margin-bottom: $textRhythm;
   }
 
   h4 {
     font-size: $fontSize;
     line-height: 1.4;
     font-weight: $labelFontWeight;
-    margin-bottom: $sizeXs;
+    margin-bottom: $textRhythm;
+  }
+
+  h5 {
+    font-size: $fontSize * 0.85;
+    line-height: 1.4;
+    font-weight: $labelFontWeight;
+    margin-bottom: $textRhythm;
+  }
+
+  h6 {
+    font-size: $fontSize * 0.75;
+    line-height: 1.4;
+    font-weight: $labelFontWeight;
+    margin-bottom: $textRhythm;
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/vectara/vectara-ui/issues/265

<img width="2338" height="1796" alt="image" src="https://github.com/user-attachments/assets/f3af6654-603f-4fa8-8219-bdd4908f450d" />
