### PR TITLE
Set type='button' on all button elements that shouldn't submit forms.

### DIFF
--- a/src/lib/components/accordion/Accordion.tsx
+++ b/src/lib/components/accordion/Accordion.tsx
@@ -27,6 +27,7 @@ export const VuiAccordion = ({ header, children, isOpen, setIsOpen, ...rest }: P
         id={buttonId}
         aria-controls={contentId}
         aria-expanded={isOpen}
+        type="button"
         {...rest}
       >
         <VuiFlexContainer alignItems="center" justifyContent="start" spacing="xxs">

--- a/src/lib/components/accountButton/AccountButton.tsx
+++ b/src/lib/components/accountButton/AccountButton.tsx
@@ -15,7 +15,7 @@ const Button = forwardRef<HTMLButtonElement | null, BaseButtonProps>(
     });
 
     return (
-      <button className={classes} {...rest} ref={ref} aria-expanded={isSelected} aria-haspopup="menu">
+      <button className={classes} type="button" {...rest} ref={ref} aria-expanded={isSelected} aria-haspopup="menu">
         {children}
       </button>
     );

--- a/src/lib/components/app/appSideNav/AppSideNav.tsx
+++ b/src/lib/components/app/appSideNav/AppSideNav.tsx
@@ -79,6 +79,7 @@ export const VuiAppSideNav = ({ size = "m", items = [], content, canCollapseSelf
                   setIsTouched(true);
                   setIsCollapsed(true);
                 }}
+                type="button"
               >
                 <VuiFlexContainer alignItems="center" spacing="xxs">
                   <VuiFlexItem shrink={false} grow={false}>

--- a/src/lib/components/badge/Badge.tsx
+++ b/src/lib/components/badge/Badge.tsx
@@ -56,7 +56,7 @@ export const VuiBadge = ({ children, className, color, onClick, onClose, href, t
 
   if (onClick) {
     return (
-      <button className={classes} onClick={onClick} {...rest}>
+      <button className={classes} onClick={onClick} type="button" {...rest}>
         {content}
       </button>
     );

--- a/src/lib/components/button/IconButton.tsx
+++ b/src/lib/components/button/IconButton.tsx
@@ -75,7 +75,7 @@ export const VuiIconButton = forwardRef<HTMLButtonElement | null, Props>(
       });
     } else {
       iconButton = (
-        <button {...props} ref={ref} disabled={isDisabled}>
+        <button type="button" {...props} ref={ref} disabled={isDisabled}>
           {buttonIcon}
         </button>
       );

--- a/src/lib/components/chat/Chat.tsx
+++ b/src/lib/components/chat/Chat.tsx
@@ -174,6 +174,7 @@ export const VuiChat = ({
         className={buttonClasses}
         onClick={() => setChatStyle("condensed")}
         ref={buttonRef}
+        type="button"
       >
         <VuiFlexContainer alignItems="center" spacing="s">
           <VuiFlexItem shrink={false} grow={false}>

--- a/src/lib/components/link/Link.tsx
+++ b/src/lib/components/link/Link.tsx
@@ -12,7 +12,7 @@ export const VuiLink = ({ children, href, target, onClick, className, track, isA
 
   if (!href) {
     return (
-      <button className={classNames("vuiLink", "vuiLink--button", className)} onClick={onClick} {...rest}>
+      <button className={classNames("vuiLink", "vuiLink--button", className)} onClick={onClick} type="button" {...rest}>
         {children}
       </button>
     );

--- a/src/lib/components/menu/MenuItem.tsx
+++ b/src/lib/components/menu/MenuItem.tsx
@@ -41,7 +41,11 @@ export const VuiMenuItem = ({ className, title, text, onClick, href, color = "ne
   }
 
   if (onClick) {
-    return <button {...props}>{content}</button>;
+    return (
+      <button type="button" {...props}>
+        {content}
+      </button>
+    );
   }
 
   return <div {...props}>{content}</div>;

--- a/src/lib/components/optionsList/OptionsListItem.tsx
+++ b/src/lib/components/optionsList/OptionsListItem.tsx
@@ -80,7 +80,14 @@ export const VuiOptionsListItem = <T extends unknown = unknown>({
   }
 
   return (
-    <button className={classes} onClick={() => onClick?.(value)} data-testid={testId} {...rest} role="menuitem">
+    <button
+      className={classes}
+      onClick={() => onClick?.(value)}
+      data-testid={testId}
+      type="button"
+      {...rest}
+      role="menuitem"
+    >
       {content}
     </button>
   );

--- a/src/lib/components/summary/SummaryCitation.tsx
+++ b/src/lib/components/summary/SummaryCitation.tsx
@@ -13,7 +13,7 @@ export const VuiSummaryCitation = ({ reference, isSelected, onClick, className, 
   });
 
   return (
-    <button className={classes} onClick={onClick} {...rest}>
+    <button className={classes} onClick={onClick} type="button" {...rest}>
       {reference}
     </button>
   );

--- a/src/lib/components/tabs/Tab.tsx
+++ b/src/lib/components/tabs/Tab.tsx
@@ -29,7 +29,7 @@ export const VuiTab = ({ children, className, href, onClick, isActive = false, .
   }
 
   return (
-    <button className={classes} onClick={onClick} {...rest}>
+    <button className={classes} onClick={onClick} type="button" {...rest}>
       {content}
     </button>
   );

--- a/src/lib/components/topicButton/TopicButton.tsx
+++ b/src/lib/components/topicButton/TopicButton.tsx
@@ -65,7 +65,7 @@ export const VuiTopicButton = ({
   }
 
   return (
-    <button className={classes} onClick={onClick} {...rest}>
+    <button className={classes} onClick={onClick} type="button" {...rest}>
       {content}
     </button>
   );


### PR DESCRIPTION
By default, `button` elements submit enclosing forms when they're clicked. They need `type="button"` on them to block this behavior.