### PR TITLE
Convert colors to CSS variables. Enable dark mode for AppHeader.

### DIFF
--- a/src/docs/pages/app/App.tsx
+++ b/src/docs/pages/app/App.tsx
@@ -12,6 +12,7 @@ import {
   VuiSpacer,
   VuiTab,
   VuiTabs,
+  VuiTextColor,
   VuiTitle,
   VuiToggle
 } from "../../../lib";
@@ -34,6 +35,7 @@ export const App = () => {
   const [padding, setPadding] = useState<AppContentPadding>("xl");
   const [isAltLayout, setIsAltLayout] = useState<boolean>(false);
   const [isAlternateHeader, setIsAlternateHeader] = useState<boolean>(false);
+  const [isDarkHeader, setIsDarkHeader] = useState<boolean>(false);
 
   const content = (
     <VuiAppContent className="appExampleContent" fullWidth={isFullWidth} padding={padding}>
@@ -64,6 +66,32 @@ export const App = () => {
 
   const DynamicLayout = isAltLayout ? AltLayout : Layout;
 
+  const headerLeftContent = (
+    <VuiFlexContainer alignItems="center" spacing="xl">
+      <VuiTitle size="xs">
+        <h1>
+          <VuiTextColor color={isDarkHeader ? "empty" : "neutral"}>App example</VuiTextColor>
+        </h1>
+      </VuiTitle>
+
+      <VuiToggle label="Alternate side nav" checked={isAltLayout} onChange={() => setIsAltLayout(!isAltLayout)} />
+
+      <VuiToggle
+        label="Alternate header layout"
+        checked={isAlternateHeader}
+        onChange={() => setIsAlternateHeader(!isAlternateHeader)}
+      />
+
+      <VuiToggle label="Dark header" checked={isDarkHeader} onChange={() => setIsDarkHeader(!isDarkHeader)} />
+    </VuiFlexContainer>
+  );
+
+  const headerRightContent = (
+    <VuiButtonPrimary className="appExample__close" color="danger" onClick={() => setIsExampleVisible(false)}>
+      Close example
+    </VuiButtonPrimary>
+  );
+
   return (
     <>
       <VuiButtonPrimary color="primary" onClick={() => setIsExampleVisible(true)}>
@@ -72,71 +100,28 @@ export const App = () => {
 
       {isExampleVisible && (
         <div className="appExample">
-          {isAlternateHeader ? (
-            <VuiAppHeader
-              content={
+          <VuiAppHeader
+            className={isDarkHeader ? "darkMode" : ""}
+            content={
+              isAlternateHeader ? (
                 <VuiGrid columns={3}>
-                  <VuiFlexContainer>
-                    <VuiTitle size="xs">
-                      <h1>
-                        <strong>App example</strong>
-                      </h1>
-                    </VuiTitle>
+                  {headerLeftContent}
 
-                    <VuiToggle
-                      label="Alternate side nav"
-                      checked={isAltLayout}
-                      onChange={() => setIsAltLayout(!isAltLayout)}
-                    />
-                    <VuiToggle
-                      label="Alternate header layout"
-                      checked={isAlternateHeader}
-                      onChange={() => setIsAlternateHeader(!isAlternateHeader)}
-                    />
-                  </VuiFlexContainer>
                   <VuiTabs className="appExample__tabs" style="enclosed">
                     <VuiTab isActive>Tab 1</VuiTab>
                     <VuiTab>Tab 2</VuiTab>
                   </VuiTabs>
-                  <VuiButtonPrimary
-                    className="appExample__close"
-                    color="danger"
-                    onClick={() => setIsExampleVisible(false)}
-                  >
-                    Close example
-                  </VuiButtonPrimary>
-                </VuiGrid>
-              }
-            />
-          ) : (
-            <VuiAppHeader
-              left={
-                <VuiFlexContainer spacing="xl">
-                  <VuiTitle size="xs">
-                    <h1>
-                      <strong>App example</strong>
-                    </h1>
-                  </VuiTitle>
 
-                  <VuiToggle
-                    label="Alternate side nav"
-                    checked={isAltLayout}
-                    onChange={() => setIsAltLayout(!isAltLayout)}
-                  />
-                  <VuiToggle
-                    label="Alternate header layout"
-                    checked={isAlternateHeader}
-                    onChange={() => setIsAlternateHeader(!isAlternateHeader)}
-                  />
+                  {headerRightContent}
+                </VuiGrid>
+              ) : (
+                <VuiFlexContainer fullWidth justifyContent="spaceBetween" alignItems="center">
+                  {headerLeftContent}
+                  {headerRightContent}
                 </VuiFlexContainer>
-              }
-              right={
-                <VuiButtonPrimary color="danger" onClick={() => setIsExampleVisible(false)}>
-                  Close example
-                </VuiButtonPrimary>
-              }
-            />
-          )}
+              )
+            }
+          />
 
           <DynamicLayout>{content}</DynamicLayout>
         </div>

--- a/src/docs/pages/app/appExample.scss
+++ b/src/docs/pages/app/appExample.scss
@@ -23,7 +23,7 @@
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  border-right: 1px solid $borderColorLight;
+  border-right: 1px solid var(--border-color-light);
 }
 
 .appExampleNav__bottom {

--- a/src/lib/components/accordion/_index.scss
+++ b/src/lib/components/accordion/_index.scss
@@ -4,20 +4,20 @@
   padding: $sizeXs $sizeS;
   // Work inside panels or other containers with different background colors.
   background-color: transparent;
-  border: 1px solid $borderColorLight;
+  border: 1px solid var(--border-color-light);
   width: 100%;
   border-radius: $sizeXxs;
 
   &:hover {
-    color: $colorPrimary;
-    background-color: $colorPrimaryLighterShade;
-    border-color: transparentize($colorPrimary, 0.5);
+    color: var(--color-primary);
+    background-color: var(--color-primary-light-shade);
+    border-color: rgba(var(--color-primary), 0.5);
     text-decoration: underline;
   }
 }
 
 .vuiAccordionHeader--isOpen {
-  color: $colorText;
+  color: var(--color-text);
   font-weight: $fontWeightBold;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0;
@@ -28,7 +28,7 @@
 }
 
 .vuiAccordionBody {
-  border: 1px solid $borderColorLight;
+  border: 1px solid var(--border-color-light);
   border-top: none;
   padding: $sizeM $sizeL;
   border-bottom-right-radius: $sizeXxs;

--- a/src/lib/components/app/appHeader.scss
+++ b/src/lib/components/app/appHeader.scss
@@ -4,10 +4,10 @@
   align-items: center;
   width: 100vw;
   height: $appHeaderHeight;
-  background-color: $colorEmptyShade;
+  background-color: var(--color-empty-shade);
   padding: $sizeXs $sizeM;
   z-index: $appHeaderZIndex;
-  border-bottom: 1px solid $borderColor;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .vuiAppHeader__inner {

--- a/src/lib/components/app/appSideNav/_index.scss
+++ b/src/lib/components/app/appSideNav/_index.scss
@@ -1,6 +1,6 @@
 @mixin appSideNavItem--m {
   display: block;
-  color: $colorText;
+  color: var(--color-text);
   font-size: $fontSizeStandard;
   padding: 0 $sizeM;
   margin-left: -$sizeM;
@@ -10,7 +10,7 @@
 
 @mixin appSideNavItem--l {
   display: block;
-  color: $colorText;
+  color: var(--color-text);
   font-size: $fontSizeMedium;
   padding: 0 $sizeM;
   padding-top: $appSideNavLinkSpacing + 2px;

--- a/src/lib/components/app/appSideNav/appSideNav.scss
+++ b/src/lib/components/app/appSideNav/appSideNav.scss
@@ -43,7 +43,7 @@
   margin-bottom: $sizeM;
 
   &:hover {
-    color: $colorPrimary;
+    color: var(--color-primary);
     text-decoration: underline;
   }
 }
@@ -65,7 +65,7 @@
 
   &:hover {
     background-color: $colorLightShade;
-    color: $colorPrimary;
+    color: var(--color-primary);
     text-decoration: underline;
   }
 }

--- a/src/lib/components/app/appSideNav/appSideNavSections.scss
+++ b/src/lib/components/app/appSideNav/appSideNavSections.scss
@@ -13,7 +13,7 @@
 }
 
 .vuiAppSideNavSection__title {
-  color: $colorText;
+  color: var(--color-text);
   font-weight: $fontWeightBold;
   font-size: $fontSizeStandard;
 }

--- a/src/lib/components/badge/_index.scss
+++ b/src/lib/components/badge/_index.scss
@@ -23,34 +23,34 @@
 // Color
 $color: (
   accent: (
-    "color": $colorAccent,
-    "background-color": transparentize($colorAccent, 0.9),
-    "border-color": transparentize($colorAccent, 0.9)
+    "color": var(--color-accent),
+    "background-color": rgba(var(--color-accent), 0.9),
+    "border-color": rgba(var(--color-accent), 0.9)
   ),
   primary: (
-    "color": $colorPrimary,
-    "background-color": transparentize($colorPrimary, 0.9),
-    "border-color": transparentize($colorPrimary, 0.9)
+    "color": var(--color-primary),
+    "background-color": rgba(var(--color-primary), 0.9),
+    "border-color": rgba(var(--color-primary), 0.9)
   ),
   success: (
-    "color": $colorSuccess,
-    "background-color": transparentize($colorSuccess, 0.9),
-    "border-color": transparentize($colorSuccess, 0.9)
+    "color": var(--color-success),
+    "background-color": rgba(var(--color-success), 0.9),
+    "border-color": rgba(var(--color-success), 0.9)
   ),
   warning: (
-    "color": $colorWarning,
-    "background-color": transparentize($colorWarning, 0.9),
-    "border-color": transparentize($colorWarning, 0.9)
+    "color": var(--color-warning),
+    "background-color": rgba(var(--color-warning), 0.9),
+    "border-color": rgba(var(--color-warning), 0.9)
   ),
   danger: (
-    "color": $colorDanger,
-    "background-color": transparentize($colorDanger, 0.9),
-    "border-color": transparentize($colorDanger, 0.9)
+    "color": var(--color-danger),
+    "background-color": rgba(var(--color-danger), 0.9),
+    "border-color": rgba(var(--color-danger), 0.9)
   ),
   neutral: (
-    "color": $colorText,
-    "background-color": $colorLightShade,
-    "border-color": transparentize($colorText, 0.9)
+    "color": var(--color-text),
+    "background-color": var(--color-light-shade),
+    "border-color": rgba(var(--color-text), 0.9)
   )
 );
 

--- a/src/lib/components/button/buttonPrimary.scss
+++ b/src/lib/components/button/buttonPrimary.scss
@@ -10,31 +10,31 @@
 $color: (
   accent: (
     "color": #ffffff,
-    "background-color": $colorAccent,
-    "border-color": $colorAccent
+    "background-color": var(--color-accent),
+    "border-color": var(--color-accent)
   ),
   primary: (
     "color": #ffffff,
-    "background-color": $colorPrimary,
-    "border-color": $colorPrimary
+    "background-color": var(--color-primary),
+    "border-color": var(--color-primary)
   ),
   success: (
     "color": #ffffff,
-    "background-color": $colorSuccess,
-    "border-color": $colorSuccess
+    "background-color": var(--color-success),
+    "border-color": var(--color-success)
   ),
   danger: (
     "color": #ffffff,
-    "background-color": $colorDanger,
-    "border-color": $colorDanger
+    "background-color": var(--color-danger),
+    "border-color": var(--color-danger)
   ),
   warning: (
     "color": #ffffff,
-    "background-color": $colorWarning,
-    "border-color": $colorWarning
+    "background-color": var(--color-warning),
+    "border-color": var(--color-warning)
   ),
   neutral: (
-    "color": $colorText,
+    "color": var(--color-text),
     "background-color": $colorEmptyShade,
     "border-color": $colorEmptyShade
   ),

--- a/src/lib/components/button/buttonSecondary.scss
+++ b/src/lib/components/button/buttonSecondary.scss
@@ -13,31 +13,31 @@
 // Color
 $color: (
   accent: (
-    "border-color": transparentize($colorAccent, 0.5),
-    "color": $colorAccent
+    "border-color": rgba(var(--color-accent), 0.5),
+    "color": var(--color-accent)
   ),
   primary: (
-    "border-color": transparentize($colorPrimary, 0.5),
-    "color": $colorPrimary
+    "border-color": rgba(var(--color-primary), 0.5),
+    "color": var(--color-primary)
   ),
   success: (
-    "border-color": transparentize($colorSuccess, 0.5),
-    "color": $colorSuccess
+    "border-color": rgba(var(--color-success), 0.5),
+    "color": var(--color-success)
   ),
   danger: (
-    "border-color": transparentize($colorDanger, 0.5),
-    "color": $colorDanger
+    "border-color": rgba(var(--color-danger), 0.5),
+    "color": var(--color-danger)
   ),
   warning: (
-    "border-color": transparentize($colorWarning, 0.5),
-    "color": $colorWarning
+    "border-color": rgba(var(--color-warning), 0.5),
+    "color": var(--color-warning)
   ),
   neutral: (
-    "border-color": $borderColor,
-    "color": $colorText
+    "border-color": var(--border-color),
+    "color": var(--color-text)
   ),
   subdued: (
-    "border-color": $borderColorLight,
+    "border-color": var(--border-color-light),
     "color": $colorSubdued
   )
 );

--- a/src/lib/components/button/buttonTertiary.scss
+++ b/src/lib/components/button/buttonTertiary.scss
@@ -16,32 +16,32 @@
 // Color
 $color: (
   accent: (
-    "color": $colorAccent,
-    "selected-color": transparentize($colorAccent, 0.9)
+    "color": var(--color-accent),
+    "selected-color": rgba(var(--color-accent), 0.9)
   ),
   primary: (
-    "color": $colorPrimary,
-    "selected-color": transparentize($colorPrimary, 0.9)
+    "color": var(--color-primary),
+    "selected-color": rgba(var(--color-primary), 0.9)
   ),
   success: (
-    "color": $colorSuccess,
-    "selected-color": transparentize($colorSuccess, 0.9)
+    "color": var(--color-success),
+    "selected-color": rgba(var(--color-success), 0.9)
   ),
   danger: (
-    "color": $colorDanger,
-    "selected-color": transparentize($colorDanger, 0.9)
+    "color": var(--color-danger),
+    "selected-color": rgba(var(--color-danger), 0.9)
   ),
   warning: (
-    "color": $colorWarning,
-    "selected-color": transparentize($colorWarning, 0.9)
+    "color": var(--color-warning),
+    "selected-color": rgba(var(--color-warning), 0.9)
   ),
   neutral: (
-    "color": $colorText,
-    "selected-color": transparentize($colorText, 0.9)
+    "color": var(--color-text),
+    "selected-color": rgba(var(--color-text), 0.9)
   ),
   subdued: (
     "color": $colorSubdued,
-    "selected-color": transparentize($colorSubdued, 0.9)
+    "selected-color": rgba(var(--color-subdued), 0.9)
   )
 );
 

--- a/src/lib/components/button/iconButton.scss
+++ b/src/lib/components/button/iconButton.scss
@@ -7,26 +7,26 @@
 
 // Color
 $color: (
-  accent: $colorAccent,
-  primary: $colorPrimary,
-  success: $colorSuccess,
-  warning: $colorWarning,
-  danger: $colorDanger,
-  neutral: $colorText,
+  accent: var(--color-accent),
+  primary: var(--color-primary),
+  success: var(--color-success),
+  warning: var(--color-warning),
+  danger: var(--color-danger),
+  neutral: var(--color-text),
   subdued: $colorSubdued
 );
 
 @each $colorName, $colorValue in $color {
   .vuiIconButton--#{$colorName} {
     color: $colorValue;
-    background-color: transparentize($color: $colorValue, $amount: 1);
+    background-color: rgba($colorValue, 1);
 
     &:hover {
-      background-color: transparentize($color: $colorValue, $amount: 0.9);
+      background-color: rgba($colorValue, 0.9);
     }
 
     &-isSelected {
-      background-color: transparentize($color: $colorValue, $amount: 0.9);
+      background-color: rgba($colorValue, 0.9);
     }
   }
 }

--- a/src/lib/components/callout/_index.scss
+++ b/src/lib/components/callout/_index.scss
@@ -23,24 +23,24 @@
 // Color
 $color: (
   accent: (
-    "border-color": $colorAccentLightShade,
-    "background-color": $colorAccentLighterShade
+    "border-color": var(--color-accent) LightShade,
+    "background-color": var(--color-accent) LighterShade
   ),
   primary: (
-    "border-color": $colorPrimaryLightShade,
-    "background-color": $colorPrimaryLighterShade
+    "border-color": var(--color-primary) LightShade,
+    "background-color": var(--color-primary) LighterShade
   ),
   success: (
-    "border-color": $colorSuccessLightShade,
-    "background-color": $colorSuccessLighterShade
+    "border-color": var(--color-success) LightShade,
+    "background-color": var(--color-success) LighterShade
   ),
   warning: (
-    "border-color": $colorWarningLightShade,
-    "background-color": $colorWarningLighterShade
+    "border-color": var(--color-warning) LightShade,
+    "background-color": var(--color-warning) LighterShade
   ),
   danger: (
-    "border-color": $colorDangerLightShade,
-    "background-color": $colorDangerLighterShade
+    "border-color": var(--color-danger) LightShade,
+    "background-color": var(--color-danger) LighterShade
   ),
   neutral: (
     "border-color": $colorMediumShade,

--- a/src/lib/components/card/_index.scss
+++ b/src/lib/components/card/_index.scss
@@ -59,7 +59,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  border-top: 1px solid $borderColorLight;
+  border-top: 1px solid var(--border-color-light);
   padding: $sizeM $sizeL;
   flex-grow: 1;
 }
@@ -105,13 +105,13 @@
 }
 
 .vuiCard--highlight {
-  border: 2px solid $colorPrimary;
+  border: 2px solid var(--color-primary);
 
   .vuiCard__header {
-    background-color: $colorPrimaryLighterShade;
+    background-color: var(--color-primary) LighterShade;
   }
 
   .vuiCard__body {
-    border-top: $colorPrimaryLighterShade;
+    border-top: var(--color-primary) LighterShade;
   }
 }

--- a/src/lib/components/chat/_index.scss
+++ b/src/lib/components/chat/_index.scss
@@ -24,9 +24,9 @@ $minChatWidth: 600px;
 .vuiChatButton {
   padding: $sizeXs $sizeS;
   font-size: $fontSizeStandard;
-  color: $colorText;
-  background-color: $colorPrimaryLighterShade;
-  border: 1px solid $borderColor;
+  color: var(--color-text);
+  background-color: var(--color-primary) LighterShade;
+  border: 1px solid var(--border-color);
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   transition: all $transitionSpeed;
   animation: popUp 0.4s cubic-bezier(0.5, 0, 0.5, 1) 1;
@@ -58,7 +58,7 @@ $minChatWidth: 600px;
   max-width: 420px;
   border-radius: $sizeXs;
   overflow: hidden;
-  border: 1px solid $borderColor;
+  border: 1px solid var(--border-color);
   background-color: $colorLightShade;
 
   @media screen and (max-height: $minChatHeight) {
@@ -103,8 +103,8 @@ $minChatWidth: 600px;
 .vuiChat__header {
   padding: $sizeXs $sizeS;
   font-size: $fontSizeStandard;
-  color: $colorText;
-  background-color: $colorPrimaryLighterShade;
+  color: var(--color-text);
+  background-color: var(--color-primary) LighterShade;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   // Ensure shadow overlaps on top of conversation.
   z-index: 2;
@@ -131,7 +131,7 @@ $minChatWidth: 600px;
 }
 
 .vuiChat__input {
-  border-top: 1px solid $borderColorLight;
+  border-top: 1px solid var(--border-color-light);
   padding: $sizeXs $sizeS;
 }
 
@@ -145,6 +145,6 @@ $minChatWidth: 600px;
   padding: $sizeXxs $sizeS;
   overflow-y: auto;
   background-color: $colorEmptyShade;
-  border: 1px solid $borderColor;
+  border: 1px solid var(--border-color);
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
 }

--- a/src/lib/components/chat/chatTurn.scss
+++ b/src/lib/components/chat/chatTurn.scss
@@ -19,14 +19,14 @@
 }
 
 .vuiChatQuestion {
-  color: $colorAccent;
+  color: var(--color-accent);
   font-weight: $fontWeightBold;
   font-size: $fontSizeStandard;
   margin-bottom: $sizeXs;
 }
 
 .vuiChatQuestion--error {
-  color: $colorDanger;
+  color: var(--color-danger);
 }
 
 .vuiChat__inspectButton {

--- a/src/lib/components/code/_index.scss
+++ b/src/lib/components/code/_index.scss
@@ -26,7 +26,7 @@
   width: 100%;
   padding: $sizeM $sizeL;
   background-color: $colorLightShade;
-  color: $colorText;
+  color: var(--color-text);
   font-family: "Roboto Mono", monospace;
   // Ensure PrismJS components wrap their lines.
   word-wrap: break-word !important;

--- a/src/lib/components/datePicker/_index.scss
+++ b/src/lib/components/datePicker/_index.scss
@@ -9,7 +9,7 @@
   }
 
   .react-datepicker__header {
-    border-bottom: 1px solid $borderColorLight;
+    border-bottom: 1px solid var(--border-color-light);
     background-color: $colorEmptyShade;
     padding: $sizeXs 0;
   }
@@ -19,15 +19,15 @@
   }
 
   .react-datepicker__navigation:hover *::before {
-    border-color: $colorPrimary;
+    border-color: var(--color-primary);
   }
 
   .react-datepicker__current-month {
-    color: $colorText;
+    color: var(--color-text);
   }
 
   .react-datepicker__month-container {
-    border-bottom: 1px solid $borderColorLight;
+    border-bottom: 1px solid var(--border-color-light);
   }
 
   .react-datepicker__month {
@@ -39,7 +39,7 @@
   }
 
   .react-datepicker__day {
-    color: $colorText;
+    color: var(--color-text);
     margin: 1px;
     border: 1px solid $colorEmptyShade;
     width: $sizeXl;
@@ -55,7 +55,7 @@
   .react-datepicker__day--in-range,
   .react-datepicker__day--in-selecting-range,
   .react-datepicker__day--range-end {
-    background-color: $colorPrimary !important;
+    background-color: var(--color-primary) !important;
     color: $colorEmptyShade;
     border-radius: $sizeXxs;
   }
@@ -72,7 +72,7 @@
     text-align: left;
 
     &:hover {
-      color: $colorPrimary;
+      color: var(--color-primary);
     }
   }
 
@@ -81,14 +81,14 @@
   }
 
   .react-datepicker__time-list-item--selected {
-    background-color: $colorPrimary !important;
+    background-color: var(--color-primary) !important;
     color: $colorEmptyShade !important;
   }
 }
 
 .vuiDatePicker--inline {
   .react-datepicker {
-    border: 1px solid $borderColor;
+    border: 1px solid var(--border-color);
   }
 }
 

--- a/src/lib/components/drawer/_index.scss
+++ b/src/lib/components/drawer/_index.scss
@@ -22,7 +22,7 @@ $drawerWidth: 680px;
   width: 100%;
   max-width: $drawerWidth;
   background-color: $colorEmptyShade;
-  border-left: 1px solid $borderColor;
+  border-left: 1px solid var(--border-color);
   z-index: $drawerZIndex;
   animation: drawerIn $transitionSpeed cubic-bezier(0, 1, 0, 1);
 }
@@ -35,7 +35,7 @@ $drawerWidth: 680px;
   font-size: $fontSizeMedium;
   font-weight: $fontWeightBold;
   line-height: 1.2;
-  color: $colorText;
+  color: var(--color-text);
 }
 
 .vuiDrawerContent {
@@ -50,10 +50,10 @@ $drawerWidth: 680px;
 // Color
 $color: (
   primary: (
-    "color": $colorPrimary
+    "color": var(--color-primary)
   ),
   danger: (
-    "color": $colorDanger
+    "color": var(--color-danger)
   )
 );
 

--- a/src/lib/components/form/input/_index.scss
+++ b/src/lib/components/form/input/_index.scss
@@ -25,5 +25,5 @@
 }
 
 .vuiInput-isInvalid {
-  border-color: $colorDanger;
+  border-color: var(--color-danger);
 }

--- a/src/lib/components/form/itemsInput/_index.scss
+++ b/src/lib/components/form/itemsInput/_index.scss
@@ -3,7 +3,7 @@
   cursor: text;
 
   &:focus-visible {
-    outline: $colorPrimary auto $sizeXxxs;
+    outline: var(--color-primary) auto $sizeXxxs;
     outline-offset: $sizeXxxs;
     -moz-outline-radius: $sizeXxs;
   }

--- a/src/lib/components/form/label/_index.scss
+++ b/src/lib/components/form/label/_index.scss
@@ -1,6 +1,6 @@
 .vuiLabel {
   font-weight: $labelFontWeight;
-  color: $labelColor;
+  color: var(--color-label);
 }
 
 .vuiLabel--xs {

--- a/src/lib/components/form/select/_index.scss
+++ b/src/lib/components/form/select/_index.scss
@@ -47,7 +47,7 @@
 
 .vuiSelect-isInvalid {
   select {
-    border-color: $colorDanger;
+    border-color: var(--color-danger);
   }
 }
 

--- a/src/lib/components/form/superRadioGroup/_index.scss
+++ b/src/lib/components/form/superRadioGroup/_index.scss
@@ -10,16 +10,16 @@
   cursor: pointer;
   text-decoration: none;
   transition: all $transitionSpeed;
-  text-decoration-color: $colorText;
+  text-decoration-color: var(--color-text);
   text-align: left;
 
   &:hover {
     text-decoration: underline;
-    text-decoration-color: $colorPrimary;
-    background-color: $colorPrimaryLighterShade;
+    text-decoration-color: var(--color-primary);
+    background-color: var(--color-primary) LighterShade;
 
     .vuiSuperRadioButton__text {
-      color: $colorPrimary !important;
+      color: var(--color-primary) !important;
     }
   }
 }

--- a/src/lib/components/form/textArea/_index.scss
+++ b/src/lib/components/form/textArea/_index.scss
@@ -10,7 +10,7 @@
 }
 
 .vuiTextArea-isInvalid {
-  border-color: $colorDanger;
+  border-color: var(--color-danger);
 }
 
 .vuiTextArea--fullWidth {

--- a/src/lib/components/horizontalRule/_index.scss
+++ b/src/lib/components/horizontalRule/_index.scss
@@ -11,25 +11,25 @@
 // Color
 $color: (
   accent: (
-    "border-color": $colorAccent
+    "border-color": var(--color-accent)
   ),
   primary: (
-    "border-color": $colorPrimary
+    "border-color": var(--color-primary)
   ),
   success: (
-    "border-color": $colorSuccess
+    "border-color": var(--color-success)
   ),
   danger: (
-    "border-color": $colorDanger
+    "border-color": var(--color-danger)
   ),
   warning: (
-    "border-color": $colorWarning
+    "border-color": var(--color-warning)
   ),
   neutral: (
-    "border-color": $borderColor
+    "border-color": var(--border-color)
   ),
   subdued: (
-    "border-color": $borderColorLight
+    "border-color": var(--border-color-light)
   )
 );
 

--- a/src/lib/components/icon/_index.scss
+++ b/src/lib/components/icon/_index.scss
@@ -12,29 +12,29 @@
 
 $color: (
   accent: (
-    "icon": $colorAccent,
-    "fill": $colorAccent,
-    "token": $colorAccentLighterShade
+    "icon": var(--color-accent),
+    "fill": var(--color-accent),
+    "token": var(--color-accent) LighterShade
   ),
   primary: (
-    "icon": $colorPrimary,
-    "fill": $colorPrimary,
-    "token": $colorPrimaryLighterShade
+    "icon": var(--color-primary),
+    "fill": var(--color-primary),
+    "token": var(--color-primary) LighterShade
   ),
   success: (
-    "icon": $colorSuccess,
-    "fill": $colorSuccess,
-    "token": $colorSuccessLighterShade
+    "icon": var(--color-success),
+    "fill": var(--color-success),
+    "token": var(--color-success) LighterShade
   ),
   warning: (
-    "icon": $colorWarning,
-    "fill": $colorWarning,
-    "token": $colorWarningLighterShade
+    "icon": var(--color-warning),
+    "fill": var(--color-warning),
+    "token": var(--color-warning) LighterShade
   ),
   danger: (
-    "icon": $colorDanger,
-    "fill": $colorDanger,
-    "token": $colorDangerLighterShade
+    "icon": var(--color-danger),
+    "fill": var(--color-danger),
+    "token": var(--color-danger) LighterShade
   ),
   subdued: (
     "icon": $colorSubdued,
@@ -42,8 +42,8 @@ $color: (
     "token": $colorLightShade
   ),
   neutral: (
-    "icon": $colorText,
-    "fill": $colorText,
+    "icon": var(--color-text),
+    "fill": var(--color-text),
     "token": $colorLightShade
   ),
   empty: (
@@ -54,22 +54,22 @@ $color: (
 );
 
 $colors: (
-  accent: $colorAccent,
-  primary: $colorPrimary,
-  success: $colorSuccess,
-  warning: $colorWarning,
-  danger: $colorDanger,
+  accent: var(--color-accent),
+  primary: var(--color-primary),
+  success: var(--color-success),
+  warning: var(--color-warning),
+  danger: var(--color-danger),
   subdued: $colorSubdued,
-  neutral: $colorText,
+  neutral: var(--color-text),
   empty: #ffffff
 );
 
 $tokenColors: (
-  accent: $colorAccentLighterShade,
-  primary: $colorPrimaryLighterShade,
-  success: $colorSuccessLighterShade,
-  warning: $colorWarningLighterShade,
-  danger: $colorDangerLighterShade,
+  accent: var(--color-accent) LighterShade,
+  primary: var(--color-primary) LighterShade,
+  success: var(--color-success) LighterShade,
+  warning: var(--color-warning) LighterShade,
+  danger: var(--color-danger) LighterShade,
   subdued: $colorMediumShade,
   neutral: $colorDarkShade,
   empty: #ffffff

--- a/src/lib/components/image/_index.scss
+++ b/src/lib/components/image/_index.scss
@@ -24,10 +24,10 @@
   border-radius: $sizeXxs;
 
   &--error {
-    background-color: $colorDangerLighterShade;
+    background-color: var(--color-danger) LighterShade;
 
     p {
-      color: $colorDanger;
+      color: var(--color-danger);
     }
   }
 }

--- a/src/lib/components/infoMenu/_index.scss
+++ b/src/lib/components/infoMenu/_index.scss
@@ -4,5 +4,5 @@
 
 .vuiInfoMenuHeader {
   padding: $sizeM;
-  border-bottom: 1px solid $borderColor;
+  border-bottom: 1px solid var(--border-color);
 }

--- a/src/lib/components/infoTable/_index.scss
+++ b/src/lib/components/infoTable/_index.scss
@@ -1,15 +1,15 @@
 .vuiInfoTable {
   width: 100%;
   table-layout: fixed;
-  border: 1px solid $borderColorLight;
+  border: 1px solid var(--border-color-light);
 
   thead {
     background-color: $colorLightShade;
-    border-bottom: 1px solid $borderColorLight;
+    border-bottom: 1px solid var(--border-color-light);
   }
 
   tbody tr {
-    border-bottom: 1px solid $borderColorLight;
+    border-bottom: 1px solid var(--border-color-light);
   }
 
   th {

--- a/src/lib/components/link/_index.scss
+++ b/src/lib/components/link/_index.scss
@@ -1,5 +1,5 @@
 .vuiLink {
-  color: $colorPrimary !important;
+  color: var(--color-primary) !important;
   text-decoration: none;
 
   &:hover {

--- a/src/lib/components/list/_index.scss
+++ b/src/lib/components/list/_index.scss
@@ -24,6 +24,6 @@
 }
 
 .vuiListNumber-isComplete {
-  background-color: $colorAccentLighterShade;
-  color: $colorAccent;
+  background-color: var(--color-accent) LighterShade;
+  color: var(--color-accent);
 }

--- a/src/lib/components/menu/_index.scss
+++ b/src/lib/components/menu/_index.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 
 .vuiMenu {
-  border: 1px solid $borderColor;
+  border: 1px solid var(--border-color);
   border-radius: $sizeXs;
   overflow: hidden;
 }
@@ -30,19 +30,19 @@
 // Color
 $color: (
   neutral: (
-    "color": $colorText,
-    "background-color": $colorPrimaryLighterShade,
-    "hover-color": $colorPrimary
+    "color": var(--color-text),
+    "background-color": var(--color-primary) LighterShade,
+    "hover-color": var(--color-primary)
   ),
   primary: (
-    "color": $colorPrimary,
-    "background-color": $colorPrimaryLighterShade,
-    "hover-color": $colorPrimary
+    "color": var(--color-primary),
+    "background-color": var(--color-primary) LighterShade,
+    "hover-color": var(--color-primary)
   ),
   danger: (
-    "color": $colorDanger,
-    "background-color": $colorDangerLighterShade,
-    "hover-color": $colorDanger
+    "color": var(--color-danger),
+    "background-color": var(--color-danger) LighterShade,
+    "hover-color": var(--color-danger)
   )
 );
 

--- a/src/lib/components/modal/_index.scss
+++ b/src/lib/components/modal/_index.scss
@@ -61,7 +61,7 @@ $modalWidth: 500px;
   font-size: $fontSizeMedium;
   font-weight: $fontWeightBold;
   line-height: 1.2;
-  color: $colorText;
+  color: var(--color-text);
 }
 
 .vuiModalContent {
@@ -76,10 +76,10 @@ $modalWidth: 500px;
 // Color
 $color: (
   primary: (
-    "color": $colorPrimary
+    "color": var(--color-primary)
   ),
   danger: (
-    "color": $colorDanger
+    "color": var(--color-danger)
   )
 );
 

--- a/src/lib/components/notification/_index.scss
+++ b/src/lib/components/notification/_index.scss
@@ -2,7 +2,7 @@
   border-radius: $sizeS;
   padding: $sizeS;
   font-size: $fontSizeStandard;
-  color: $colorText;
+  color: var(--color-text);
   width: 420px;
   box-shadow: $shadowLargeStart;
   background-color: $colorEmptyShade;

--- a/src/lib/components/optionsButton/_index.scss
+++ b/src/lib/components/optionsButton/_index.scss
@@ -17,7 +17,7 @@ $colorPrimaryButton: (
   success: transparentize($colorEmptyShade, 0.5),
   danger: transparentize($colorEmptyShade, 0.5),
   warning: transparentize($colorEmptyShade, 0.5),
-  neutral: transparentize($colorText, 0.8)
+  neutral: rgba(var(--color-text), 0.8)
 );
 
 @each $colorName, $colorValue in $colorPrimaryButton {
@@ -26,16 +26,16 @@ $colorPrimaryButton: (
   }
 }
 
-$coloSecondaryButton: (
-  accent: transparentize($colorAccent, 0.7),
-  primary: transparentize($colorPrimary, 0.7),
-  success: transparentize($colorSuccess, 0.7),
-  danger: transparentize($colorDanger, 0.7),
-  warning: transparentize($colorWarning, 0.7),
-  neutral: transparentize($colorText, 0.8)
+$colorSecondaryButton: (
+  accent: rgba(var(--color-accent), 0.7),
+  primary: rgba(var(--color-primary), 0.7),
+  success: rgba(var(--color-success), 0.7),
+  danger: rgba(var(--color-danger), 0.7),
+  warning: rgba(var(--color-warning), 0.7),
+  neutral: rgba(var(--color-text), 0.8)
 );
 
-@each $colorName, $colorValue in $coloSecondaryButton {
+@each $colorName, $colorValue in $colorSecondaryButton {
   .vuiButtonSecondary.vuiOptionsButtonRight--#{$colorName} {
     border-left-color: $colorValue;
   }

--- a/src/lib/components/optionsList/_index.scss
+++ b/src/lib/components/optionsList/_index.scss
@@ -45,34 +45,34 @@
 // Color
 $color: (
   accent: (
-    "color": $colorAccent,
-    "hover-color": $colorAccent,
-    "selected-color": $colorAccentLighterShade
+    "color": var(--color-accent),
+    "hover-color": var(--color-accent),
+    "selected-color": var(--color-accent) LighterShade
   ),
   primary: (
-    "color": $colorPrimary,
-    "hover-color": $colorPrimary,
-    "selected-color": $colorPrimaryLighterShade
+    "color": var(--color-primary),
+    "hover-color": var(--color-primary),
+    "selected-color": var(--color-primary) LighterShade
   ),
   success: (
-    "color": $colorSuccess,
-    "hover-color": $colorSuccess,
-    "selected-color": $colorSuccessLighterShade
+    "color": var(--color-success),
+    "hover-color": var(--color-success),
+    "selected-color": var(--color-success) LighterShade
   ),
   danger: (
-    "color": $colorDanger,
-    "hover-color": $colorDanger,
-    "selected-color": $colorDangerLighterShade
+    "color": var(--color-danger),
+    "hover-color": var(--color-danger),
+    "selected-color": var(--color-danger) LighterShade
   ),
   warning: (
-    "color": $colorWarning,
-    "hover-color": $colorWarning,
-    "selected-color": $colorWarningLighterShade
+    "color": var(--color-warning),
+    "hover-color": var(--color-warning),
+    "selected-color": var(--color-warning) LighterShade
   ),
   neutral: (
-    "color": $colorText,
-    "hover-color": $colorPrimary,
-    "selected-color": $colorPrimaryLighterShade
+    "color": var(--color-text),
+    "hover-color": var(--color-primary),
+    "selected-color": var(--color-primary) LighterShade
   )
 );
 

--- a/src/lib/components/popover/_index.scss
+++ b/src/lib/components/popover/_index.scss
@@ -1,7 +1,7 @@
 .vuiPopover {
   position: absolute;
   background-color: $colorEmptyShade;
-  border: 1px solid $borderColor;
+  border: 1px solid var(--border-color);
   z-index: $popoverZIndex;
   box-shadow: $shadowLargeEnd;
   border-radius: $sizeXxs;
@@ -32,7 +32,7 @@
 
 .vuiPopoverTitle {
   padding: $sizeXs $sizeS;
-  border-bottom: 1px solid $borderColor;
+  border-bottom: 1px solid var(--border-color);
   font-weight: $fontWeightBold;
   font-size: $fontSizeStandard;
   color: $colorDarkerShade;

--- a/src/lib/components/progressBar/_index.scss
+++ b/src/lib/components/progressBar/_index.scss
@@ -35,19 +35,19 @@
 // Color
 $color: (
   accent: (
-    "background-color": linear-gradient(to top, $colorAccent, $colorAccentLightShade)
+    "background-color": linear-gradient(to top, var(--color-accent), var(--color-accent) LightShade)
   ),
   primary: (
-    "background-color": linear-gradient(to top, $colorPrimary, $colorPrimaryLightShade)
+    "background-color": linear-gradient(to top, var(--color-primary), var(--color-primary) LightShade)
   ),
   success: (
-    "background-color": linear-gradient(to top, $colorSuccess, $colorSuccessLightShade)
+    "background-color": linear-gradient(to top, var(--color-success), var(--color-success) LightShade)
   ),
   warning: (
-    "background-color": linear-gradient(to top, $colorWarning, $colorWarningLightShade)
+    "background-color": linear-gradient(to top, var(--color-warning), var(--color-warning) LightShade)
   ),
   danger: (
-    "background-color": linear-gradient(to top, $colorDanger, $colorDangerLightShade)
+    "background-color": linear-gradient(to top, var(--color-danger), var(--color-danger) LightShade)
   ),
   neutral: (
     "background-color": linear-gradient(to top, $colorDarkShade, $colorMediumShade)

--- a/src/lib/components/prompt/_index.scss
+++ b/src/lib/components/prompt/_index.scss
@@ -29,16 +29,16 @@
 
 .vuiPrompt--interactive {
   &:hover {
-    background-color: $colorAccentLighterShade;
-    color: $colorAccent;
+    background-color: var(--color-accent) LighterShade;
+    color: var(--color-accent);
   }
 }
 
 // Color
 $color: (
   danger: (
-    "color": $colorDanger,
-    "background-color": $colorDangerLighterShade
+    "color": var(--color-danger),
+    "background-color": var(--color-danger) LighterShade
   ),
   neutral: (
     "color": $colorDarkShade,

--- a/src/lib/components/screenBlock/_index.scss
+++ b/src/lib/components/screenBlock/_index.scss
@@ -24,18 +24,18 @@
 
 .vuiScreenBlock--primary {
   .vuiScreenBlock__mask {
-    background-color: transparentize($colorPrimary, 0.4);
+    background-color: rgba(var(--color-primary), 0.4);
   }
 }
 
 .vuiScreenBlock--success {
   .vuiScreenBlock__mask {
-    background-color: transparentize($colorSuccess, 0.4);
+    background-color: rgba(var(--color-success), 0.4);
   }
 }
 
 .vuiScreenBlock--danger {
   .vuiScreenBlock__mask {
-    background-color: transparentize($colorDanger, 0.4);
+    background-color: rgba(var(--color-danger), 0.4);
   }
 }

--- a/src/lib/components/searchInput/_index.scss
+++ b/src/lib/components/searchInput/_index.scss
@@ -23,7 +23,7 @@
   outline-offset: -1px !important;
 
   &:focus-visible {
-    outline-color: $colorPrimary !important;
+    outline-color: var(--color-primary) !important;
     box-shadow: $shadowSmallEnd;
   }
 }
@@ -41,7 +41,7 @@
   transition: color $transitionSpeed;
 
   &:hover {
-    color: $colorAccent;
+    color: var(--color-accent);
   }
 }
 
@@ -77,7 +77,7 @@
   transition: all $transitionSpeed;
 
   &:hover {
-    color: $colorAccent;
+    color: var(--color-accent);
   }
 }
 .vuiSearchInputSuggestionsContainer {
@@ -114,13 +114,13 @@
   text-decoration: none;
   padding: ($sizeXxs + 1px) $sizeS;
   font-size: $fontSizeStandard;
-  color: $colorText;
+  color: var(--color-text);
 
   &:focus-visible,
   &:hover {
     text-decoration: underline;
-    color: $colorPrimary;
-    background-color: $colorPrimaryLighterShade;
+    color: var(--color-primary);
+    background-color: var(--color-primary) LighterShade;
   }
 
   &:focus-visible {

--- a/src/lib/components/searchResult/_index.scss
+++ b/src/lib/components/searchResult/_index.scss
@@ -23,7 +23,7 @@
 }
 
 .vuiSearchResultPosition--selected {
-  background-color: $colorPrimary;
+  background-color: var(--color-primary);
   color: $colorEmptyShade;
   height: 100%;
 }

--- a/src/lib/components/searchSelect/_index.scss
+++ b/src/lib/components/searchSelect/_index.scss
@@ -1,7 +1,7 @@
 .vuiSearchSelectHeader {
   background-color: $colorLightShade;
   padding: $sizeM;
-  border-bottom: 1px solid $borderColor;
+  border-bottom: 1px solid var(--border-color);
   font-weight: $fontWeightBold;
   font-size: $fontSizeStandard;
   color: $colorDarkerShade;
@@ -9,7 +9,7 @@
 
 .vuiSearchSelect__search {
   padding: $sizeXxs $sizeXs;
-  border-bottom: 1px solid $borderColor;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .vuiSearchSelect__emptyMessage {

--- a/src/lib/components/skeleton/_index.scss
+++ b/src/lib/components/skeleton/_index.scss
@@ -39,19 +39,19 @@
 // Color variants
 $color: (
   accent: (
-    "backgroundColor": $colorAccentLighterShade
+    "backgroundColor": var(--color-accent) LighterShade
   ),
   primary: (
-    "backgroundColor": $colorPrimaryLighterShade
+    "backgroundColor": var(--color-primary) LighterShade
   ),
   success: (
-    "backgroundColor": $colorSuccessLighterShade
+    "backgroundColor": var(--color-success) LighterShade
   ),
   danger: (
-    "backgroundColor": $colorDangerLighterShade
+    "backgroundColor": var(--color-danger) LighterShade
   ),
   warning: (
-    "backgroundColor": $colorWarningLighterShade
+    "backgroundColor": var(--color-warning) LighterShade
   ),
   neutral: (
     "backgroundColor": $colorMediumShade

--- a/src/lib/components/spinner/_index.scss
+++ b/src/lib/components/spinner/_index.scss
@@ -7,19 +7,19 @@
 // Color
 $color: (
   accent: (
-    "color": $colorAccent
+    "color": var(--color-accent)
   ),
   primary: (
-    "color": $colorPrimary
+    "color": var(--color-primary)
   ),
   success: (
-    "color": $colorSuccess
+    "color": var(--color-success)
   ),
   danger: (
-    "color": $colorDanger
+    "color": var(--color-danger)
   ),
   warning: (
-    "color": $colorWarning
+    "color": var(--color-warning)
   ),
   empty: (
     "color": $colorEmptyShade

--- a/src/lib/components/steps/_index.scss
+++ b/src/lib/components/steps/_index.scss
@@ -119,14 +119,14 @@ $stepSizeM: 36px;
   }
 
   &--complete {
-    background-color: $colorSuccessLighterShade;
+    background-color: var(--color-success) LighterShade;
   }
 
   &--current {
-    color: $colorPrimary;
+    color: var(--color-primary);
     width: calc(var(--step-size) - 4px);
     height: calc(var(--step-size) - 4px);
-    box-shadow: 0 0 0 2px $colorPrimary;
+    box-shadow: 0 0 0 2px var(--color-primary);
     margin-top: 2px;
     margin-bottom: 2px;
   }
@@ -138,11 +138,11 @@ $stepSizeM: 36px;
   }
 
   &--warning {
-    background-color: $colorWarningLighterShade;
+    background-color: var(--color-warning) LighterShade;
   }
 
   &--danger {
-    background-color: $colorDangerLighterShade;
+    background-color: var(--color-danger) LighterShade;
   }
 
   &--disabled {
@@ -171,7 +171,7 @@ $stepSizeM: 36px;
   color: $colorSubdued;
 
   .vuiStep__title--current & {
-    color: $colorPrimary;
+    color: var(--color-primary);
   }
 }
 
@@ -182,7 +182,7 @@ $stepSizeM: 36px;
   text-align: center;
 
   &--current {
-    color: $colorPrimary;
+    color: var(--color-primary);
   }
 
   .vuiStep--disabled & {

--- a/src/lib/components/summary/_index.scss
+++ b/src/lib/components/summary/_index.scss
@@ -17,13 +17,13 @@
   transition: all $transitionSpeed;
 
   &:hover {
-    color: $colorPrimary;
-    background-color: $colorPrimaryLighterShade;
+    color: var(--color-primary);
+    background-color: var(--color-primary) LighterShade;
     text-decoration: underline;
   }
 }
 
 .vuiSummaryCitation-isSelected {
-  background-color: $colorPrimary;
+  background-color: var(--color-primary);
   color: $colorEmptyShade;
 }

--- a/src/lib/components/table/_index.scss
+++ b/src/lib/components/table/_index.scss
@@ -19,11 +19,11 @@
   table-layout: fixed;
 
   thead {
-    border-bottom: 1px solid $borderColor;
+    border-bottom: 1px solid var(--border-color);
   }
 
   tbody tr {
-    border-bottom: 1px solid $borderColorLight;
+    border-bottom: 1px solid var(--border-color-light);
 
     &.vuiTableRow-isBeingActedUpon,
     &:not(.vuiTableRow--inert):hover {
@@ -33,7 +33,7 @@
     }
 
     &:last-child {
-      border-bottom: 1px solid $borderColor;
+      border-bottom: 1px solid var(--border-color);
     }
 
     .vuiTableCell__label {
@@ -69,7 +69,7 @@
 .vuiTableCell__label {
   font-size: $fontSizeSmall;
   font-weight: $labelFontWeight;
-  color: $labelColor;
+  color: var(--color-label);
 }
 
 @container (width < 800px) {

--- a/src/lib/components/tabs/_open.scss
+++ b/src/lib/components/tabs/_open.scss
@@ -1,6 +1,6 @@
 .vuiTabs--open {
   display: flex;
-  border-bottom: 1px solid $borderColorLight;
+  border-bottom: 1px solid var(--border-color-light);
 
   &.vuiTabs--s {
     .vuiTab {
@@ -24,17 +24,17 @@
 
     &:hover {
       .vuiTab__inner {
-        color: $colorPrimary;
-        background-color: $colorPrimaryLighterShade;
+        color: var(--color-primary);
+        background-color: var(--color-primary) LighterShade;
 
         .vuiIcon__inner {
-          color: $colorPrimary !important;
+          color: var(--color-primary) !important;
         }
       }
     }
 
     &.vuiTab-isActive {
-      box-shadow: $borderColor 0px 1px 0px;
+      box-shadow: var(--border-color) 0px 1px 0px;
 
       .vuiTab__inner {
         background-color: $colorLightShade;

--- a/src/lib/components/timeline/_index.scss
+++ b/src/lib/components/timeline/_index.scss
@@ -22,7 +22,7 @@ $iconWidth: 36px;
 }
 
 .vuiTimelineContainer--bordered {
-  border-left: 2px solid $borderColorLight;
+  border-left: 2px solid var(--border-color-light);
 }
 
 .vuiTimelineItem {

--- a/src/lib/components/toggle/Toggle.tsx
+++ b/src/lib/components/toggle/Toggle.tsx
@@ -1,6 +1,7 @@
 import { createId } from "../../utils/createId";
 import { VuiFlexContainer } from "../flex/FlexContainer";
 import { VuiFlexItem } from "../flex/FlexItem";
+import { VuiText } from "../typography/Text";
 
 type Props = {
   id?: string;
@@ -37,7 +38,11 @@ export const VuiToggle = ({ id, checked, onChange, label, ...rest }: Props) => {
 
       {label && (
         <VuiFlexItem grow={false}>
-          <div id={labelId}>{label}</div>
+          <div id={labelId}>
+            <VuiText>
+              <p>{label}</p>
+            </VuiText>
+          </div>
         </VuiFlexItem>
       )}
     </VuiFlexContainer>

--- a/src/lib/components/toggle/_index.scss
+++ b/src/lib/components/toggle/_index.scss
@@ -17,11 +17,11 @@ $buttonWidth: $toggleWidth * 0.75 - ($buttonOffset * 2);
   height: 0;
 
   &:checked + .vuiToggle__button {
-    background-color: $colorPrimary;
+    background-color: var(--color-primary);
   }
 
   &:focus-visible + .vuiToggle__button {
-    outline: 2px solid transparentize($colorPrimary, 0.25);
+    outline: 2px solid rgba(var(--color-primary), 0.25);
     outline-offset: 2px;
   }
 
@@ -37,7 +37,7 @@ $buttonWidth: $toggleWidth * 0.75 - ($buttonOffset * 2);
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: $colorMediumShade;
+  background-color: var(--color-medium-shade);
   transition: $transitionSpeed;
   border-radius: $buttonHeight;
   box-shadow: inset rgba(0, 0, 0, 0.1) 0px 2px 2px;
@@ -49,7 +49,7 @@ $buttonWidth: $toggleWidth * 0.75 - ($buttonOffset * 2);
     width: $buttonWidth;
     left: $buttonOffset;
     bottom: $buttonOffset;
-    background-color: $colorEmptyShade;
+    background-color: var(--color-empty-shade);
     transition: $transitionSpeed;
     border-radius: $buttonHeight;
   }

--- a/src/lib/components/topicButton/_index.scss
+++ b/src/lib/components/topicButton/_index.scss
@@ -11,7 +11,7 @@
 
   &:hover {
     text-decoration: none;
-    box-shadow: $shadowLargeEnd, $colorPrimary 0 0 1px 1px;
+    box-shadow: $shadowLargeEnd, var(--color-primary) 0 0 1px 1px;
     z-index: 1;
   }
 }

--- a/src/lib/components/typography/_text.scss
+++ b/src/lib/components/typography/_text.scss
@@ -7,7 +7,7 @@ $textRhythm: $sizeM;
   word-break: break-word;
 
   a {
-    color: $colorPrimary !important;
+    color: var(--color-primary) !important;
     text-decoration: none;
 
     &:hover {
@@ -35,7 +35,7 @@ $textRhythm: $sizeM;
     border-right: none;
     border-bottom: 1px solid;
     width: 100%;
-    border-bottom-color: $borderColor;
+    border-bottom-color: var(--border-color);
     margin-bottom: $textRhythm;
   }
 
@@ -79,16 +79,16 @@ $textRhythm: $sizeM;
   table {
     width: 100%;
     table-layout: fixed;
-    border: 1px solid $borderColorLight;
+    border: 1px solid var(--border-color-light);
     margin-bottom: $textRhythm;
 
     thead {
       background-color: $colorLightShade;
-      border-bottom: 1px solid $borderColorLight;
+      border-bottom: 1px solid var(--border-color-light);
     }
 
     tbody tr {
-      border-bottom: 1px solid $borderColorLight;
+      border-bottom: 1px solid var(--border-color-light);
     }
 
     th {
@@ -119,7 +119,7 @@ $textRhythm: $sizeM;
 }
 
 @mixin defineTextStyles($fontSize, $fontWeight) {
-  color: $colorText;
+  color: var(--color-text);
   font-size: $fontSize;
   line-height: 1.4;
 

--- a/src/lib/components/typography/_textColor.scss
+++ b/src/lib/components/typography/_textColor.scss
@@ -1,12 +1,12 @@
 $color: (
-  accent: $colorAccent,
-  primary: $colorPrimary,
-  success: $colorSuccess,
-  warning: $colorWarning,
-  danger: $colorDanger,
+  accent: var(--color-accent),
+  primary: var(--color-primary),
+  success: var(--color-success),
+  warning: var(--color-warning),
+  danger: var(--color-danger),
   subdued: $colorSubdued,
-  neutral: $colorText,
-  empty: $colorEmptyShade,
+  neutral: var(--color-text),
+  empty: $colorEmptyShade
 );
 
 @each $colorName, $colorValue in $color {

--- a/src/lib/components/typography/_title.scss
+++ b/src/lib/components/typography/_title.scss
@@ -1,7 +1,7 @@
 @use "sass:map";
 
 .vuiTitle {
-  color: $colorText;
+  color: var(--color-text);
   margin-bottom: 0;
 }
 
@@ -10,43 +10,43 @@ $size: (
     size: $fontSizeSmall,
     line-height: 1.4,
     weight: $fontWeightBold,
-    color: $colorText
+    color: var(--color-text)
   ),
   xs: (
     size: $fontSizeStandard,
     line-height: 1.4,
     weight: $labelFontWeight,
-    color: $labelColor
+    color: var(--color-label)
   ),
   s: (
     size: $fontSizeLarge,
     line-height: 1.3,
     weight: $fontWeightNormal,
-    color: $colorText
+    color: var(--color-text)
   ),
   m: (
     size: $fontSizeXLarge,
     weight: $fontWeightNormal,
     line-height: 1.2,
-    color: $colorText
+    color: var(--color-text)
   ),
   l: (
     size: $fontSizeXxLarge,
     weight: $fontWeightStrong,
     line-height: 1.1,
-    color: $colorText
+    color: var(--color-text)
   ),
   xl: (
     size: $fontSizeXxxLarge,
     weight: $fontWeightStrong,
     line-height: 1,
-    color: $colorText
+    color: var(--color-text)
   ),
   xxl: (
     size: $fontSizeXxxLarge,
     line-height: 1,
     weight: $fontWeightStrong,
-    color: $colorText
+    color: var(--color-text)
   )
 );
 

--- a/src/lib/sassUtils/_borders.scss
+++ b/src/lib/sassUtils/_borders.scss
@@ -1,2 +1,0 @@
-$borderColor: $colorMediumShade;
-$borderColorLight: #e3e4f3;

--- a/src/lib/sassUtils/_colors.scss
+++ b/src/lib/sassUtils/_colors.scss
@@ -30,3 +30,89 @@ $colorMediumShade: #cbd1de !default;
 $colorDarkShade: #3f4551 !default;
 $colorDarkerShade: #1c1d22 !default;
 $colorFullShade: #0b0c0e !default;
+
+:root,
+.lightMode {
+  // Semantic colors
+  --color-accent: #{$colorAccent};
+  --color-accent-light-shade: #{$colorAccentLightShade};
+  --color-accent-lighter-shade: #{$colorAccentLighterShade};
+
+  --color-primary: #{$colorPrimary};
+  --color-primary-light-shade: #{$colorPrimaryLightShade};
+  --color-primary-lighter-shade: #{$colorPrimaryLighterShade};
+
+  --color-success: #{$colorSuccess};
+  --color-success-light-shade: #{$colorSuccessLightShade};
+  --color-success-lighter-shade: #{$colorSuccessLighterShade};
+
+  --color-warning: #{$colorWarning};
+  --color-warning-light-shade: #{$colorWarningLightShade};
+  --color-warning-lighter-shade: #{$colorWarningLighterShade};
+
+  --color-danger: #{$colorDanger};
+  --color-danger-light-shade: #{$colorDangerLightShade};
+  --color-danger-lighter-shade: #{$colorDangerLighterShade};
+
+  // Special colors
+  --color-primary-highlight: #{$colorPrimaryHighlight};
+  --color-subdued: #{$colorSubdued};
+
+  // Neutral colors
+  --color-empty-shade: #{$colorEmptyShade};
+  --color-light-shade: #{$colorLightShade};
+  --color-medium-shade: #{$colorMediumShade};
+  --color-dark-shade: #{$colorDarkShade};
+  --color-darker-shade: #{$colorDarkerShade};
+  --color-full-shade: #{$colorFullShade};
+
+  // Text color.
+  --color-text: var(--color-darker-shade);
+  --color-label: var(--color-text);
+
+  // Border color.
+  --border-color: var(--color-medium-shade);
+  --border-color-light: #e3e4f3;
+}
+
+.darkMode {
+  // // Semantic colors
+  // --color-accent: #{$colorAccentLighterShade};
+  // --color-accent-light-shade: #{$colorAccentLightShade};
+  // --color-accent-lighter-shade: #{$colorAccent};
+
+  // --color-primary: #{$colorPrimaryLighterShade};
+  // --color-primary-light-shade: #{$colorPrimaryLightShade};
+  // --color-primary-lighter-shade: #{$colorPrimary};
+
+  // --color-success: #{$colorSuccessLighterShade};
+  // --color-success-light-shade: #{$colorSuccessLightShade};
+  // --color-success-lighter-shade: #{$colorSuccess};
+
+  // --color-warning: #{$colorWarningLighterShade};
+  // --color-warning-light-shade: #{$colorWarningLightShade};
+  // --color-warning-lighter-shade: #{$colorWarningLighterShade};
+
+  // --color-danger: #{$colorDangerLighterShade};
+  // --color-danger-light-shade: #{$colorDangerLightShade};
+  // --color-danger-lighter-shade: #{$colorDanger};
+
+  // Special colors
+  --color-primary-highlight: #{$colorPrimaryHighlight};
+  --color-subdued: #{$colorSubdued};
+
+  // Neutral colors
+  --color-empty-shade: #{$colorFullShade};
+  --color-light-shade: #{$colorDarkerShade};
+  --color-medium-shade: #{$colorDarkShade};
+  --color-dark-shade: #{$colorMediumShade};
+  --color-darker-shade: #{$colorLightShade};
+  --color-full-shade: #{$colorEmptyShade};
+
+  // Text color.
+  --color-text: var(--color-darker-shade);
+  --color-label: var(--color-text);
+
+  // Border color.
+  --border-color-light: #323338;
+}

--- a/src/lib/sassUtils/_typography.scss
+++ b/src/lib/sassUtils/_typography.scss
@@ -8,9 +8,6 @@ $fontSizeXLarge: 24px;
 $fontSizeXxLarge: 30px;
 $fontSizeXxxLarge: 40px;
 
-$colorText: $colorDarkerShade;
-$colorSubdued: $colorSubdued;
-
 $fontWeightLight: 300;
 $fontWeightNormal: 400;
 $fontWeightStrong: 500;
@@ -18,4 +15,3 @@ $fontWeightBold: 600;
 $fontWeightHeavy: 800;
 
 $labelFontWeight: $fontWeightBold;
-$labelColor: $colorText;

--- a/src/lib/sassUtils/index.scss
+++ b/src/lib/sassUtils/index.scss
@@ -2,7 +2,6 @@
 @import "colors";
 @import "depth";
 @import "sizes";
-@import "borders";
 @import "shadows";
 @import "typography";
 @import "animation";

--- a/src/lib/styles/_focus.scss
+++ b/src/lib/styles/_focus.scss
@@ -3,7 +3,7 @@
 }
 
 :focus-visible {
-  outline: $colorPrimary auto $sizeXxxs;
+  outline: var(--color-primary) auto $sizeXxxs;
   outline-offset: $sizeXxxs;
   -moz-outline-radius: $sizeXxs;
 }


### PR DESCRIPTION
This enables a dark AppHeader, which takes intermediate steps towards enabling a general dark mode using CSS variables. The removal of some SCSS variables is a breaking change.

<img width="1333" height="289" alt="image" src="https://github.com/user-attachments/assets/301dacae-f32d-4791-bfe0-50dbbadee7ac" />
