### PR TITLE
Feat: custom portal container prop in VuiContext

### DIFF
--- a/src/docs/pages.tsx
+++ b/src/docs/pages.tsx
@@ -57,6 +57,7 @@ import { tabs } from "./pages/tabs";
 import { text } from "./pages/text";
 import { textArea } from "./pages/textArea";
 import { theme } from "./pages/theme";
+import { portalContainer } from "./pages/portalContainer";
 import { timeline } from "./pages/timeline";
 import { toggle } from "./pages/toggle";
 import { tooltip } from "./pages/tooltip";
@@ -77,7 +78,7 @@ export const categories: Category[] = [
   },
   {
     name: "Application",
-    pages: [app, drawer, modal, notifications, accountButton, theme]
+    pages: [app, drawer, modal, portalContainer, notifications, accountButton, theme]
   },
   {
     name: "Info",

--- a/src/docs/pages/portalContainer/PortalContainer.tsx
+++ b/src/docs/pages/portalContainer/PortalContainer.tsx
@@ -1,0 +1,36 @@
+import { LinkProps, VuiButtonPrimary, VuiContextProvider, VuiModal } from "../../../lib";
+import { Link, useLocation } from "react-router-dom";
+import { useRef, useState } from "react";
+
+export const PortalContainer = () => {
+  const location = useLocation();
+  const ref = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const linkProvider = (linkConfig: LinkProps) => {
+    const { className, href, onClick, children, ...rest } = linkConfig;
+
+    return (
+      <Link className={className} to={href ?? ""} onClick={onClick} {...rest}>
+        {children}
+      </Link>
+    );
+  };
+
+  const pathProvider = () => {
+    return location.pathname;
+  };
+
+  return (
+    <div ref={ref}>
+      <VuiContextProvider linkProvider={linkProvider} pathProvider={pathProvider} portalContainer={ref.current!}>
+        <VuiButtonPrimary color="primary" onClick={() => setOpen(true)}>
+          Open modal inside custom portal container
+        </VuiButtonPrimary>
+        <VuiModal title="Portal Container Modal" isOpen={open} onClose={() => setOpen(false)}>
+          This modal is rendered inside a custom portal container.
+        </VuiModal>
+      </VuiContextProvider>
+    </div>
+  );
+};

--- a/src/docs/pages/portalContainer/index.tsx
+++ b/src/docs/pages/portalContainer/index.tsx
@@ -1,0 +1,15 @@
+import { PortalContainer } from "./PortalContainer";
+
+const PortalContainerSource = require("!!raw-loader!./PortalContainer");
+
+export const portalContainer = {
+  name: "Portal Container",
+  path: "/portal-container",
+  examples: [
+    {
+      name: "Custom portal container",
+      component: <PortalContainer />,
+      source: PortalContainerSource.default.toString()
+    }
+  ]
+};

--- a/src/lib/components/context/Context.tsx
+++ b/src/lib/components/context/Context.tsx
@@ -10,6 +10,7 @@ interface VuiContextType {
   getPath: PathProvider;
   DrawerTitle: keyof JSX.IntrinsicElements;
   getThemeStyle: (theme: "dark" | "light") => Record<string, string>;
+  portalContainer?: HTMLElement;
 }
 
 const VuiContext = createContext<VuiContextType | undefined>(undefined);
@@ -21,6 +22,7 @@ type Props = {
   drawerTitle?: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   theme?: Theme;
   isThemeIsolated?: boolean;
+  portalContainer?: HTMLElement;
 };
 
 export const VuiContextProvider = ({
@@ -29,6 +31,7 @@ export const VuiContextProvider = ({
   pathProvider,
   drawerTitle = "h2",
   theme = LIGHT_THEME,
+  portalContainer = document.body,
   isThemeIsolated
 }: Props) => {
   const createLink = (linkConfig: LinkProps) => {
@@ -75,7 +78,7 @@ export const VuiContextProvider = ({
   const themedChildren = isThemeIsolated ? <div style={cssVariables}>{children}</div> : children;
 
   return (
-    <VuiContext.Provider value={{ createLink, getPath, DrawerTitle, getThemeStyle }}>
+    <VuiContext.Provider value={{ createLink, getPath, DrawerTitle, getThemeStyle, portalContainer }}>
       {themedChildren}
     </VuiContext.Provider>
   );

--- a/src/lib/components/portal/Portal.tsx
+++ b/src/lib/components/portal/Portal.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { useVuiContext } from "../context/Context";
 
 type Props = {
   children: ReactNode;
@@ -9,14 +10,17 @@ export const VuiPortal = ({ children }: Props) => {
   // Initialize ref synchronously during the first render, ensuring portalRef.current
   // is immediately available for createPortal.
   const portalRef = useRef<HTMLDivElement>(document.createElement("div"));
+  const { portalContainer } = useVuiContext();
 
   useEffect(() => {
-    document.body.appendChild(portalRef.current);
+    if (!portalContainer) return;
+
+    portalContainer.appendChild(portalRef.current);
 
     return () => {
       portalRef.current.parentNode?.removeChild(portalRef.current);
     };
-  }, []);
+  }, [portalContainer]);
 
   return createPortal(children, portalRef.current);
 };


### PR DESCRIPTION
Adds an optional prop `portalContainer` to `VuiContext` to allow consumers override the default portal container (`document.body`).

**Context**:
When we mount a component as a web component for css isolation, with Vui as its dependency, the modals and drawers etc. from that component are not loaded inside the shadow dom of the web component, losing their css. This change allows providing a portal container that can be within the WC's shadow dom to allow portal's children access the WC's styles.