### PR TITLE
Add support for select all rows checkbox on responsive table. Improve data-testid support.

### DIFF
--- a/src/docs/pages/table/Table.tsx
+++ b/src/docs/pages/table/Table.tsx
@@ -4,13 +4,12 @@ import {
   VuiCopyButton,
   VuiFlexContainer,
   VuiFlexItem,
-  VuiFormGroup,
   VuiIcon,
   VuiLink,
+  VuiSelect,
   VuiSpacer,
   VuiText,
   VuiTextColor,
-  VuiTextInput,
   VuiToggle
 } from "../../../lib";
 import { VuiTable } from "../../../lib/components/table/Table";
@@ -91,24 +90,25 @@ export const Table = () => {
       : [];
 
     // Apply sorting
-    const sortedPeople = sortColumn && sortDirection !== "none"
-      ? [...filteredPeople].sort((a, b) => {
-          const aValue = a[sortColumn as keyof Person];
-          const bValue = b[sortColumn as keyof Person];
+    const sortedPeople =
+      sortColumn && sortDirection !== "none"
+        ? [...filteredPeople].sort((a, b) => {
+            const aValue = a[sortColumn as keyof Person];
+            const bValue = b[sortColumn as keyof Person];
 
-          // Handle arrays (like roles)
-          if (Array.isArray(aValue) && Array.isArray(bValue)) {
-            const aStr = aValue.join(", ");
-            const bStr = bValue.join(", ");
+            // Handle arrays (like roles)
+            if (Array.isArray(aValue) && Array.isArray(bValue)) {
+              const aStr = aValue.join(", ");
+              const bStr = bValue.join(", ");
+              return sortDirection === "asc" ? aStr.localeCompare(bStr) : bStr.localeCompare(aStr);
+            }
+
+            // Handle strings
+            const aStr = String(aValue);
+            const bStr = String(bValue);
             return sortDirection === "asc" ? aStr.localeCompare(bStr) : bStr.localeCompare(aStr);
-          }
-
-          // Handle strings
-          const aStr = String(aValue);
-          const bStr = String(bValue);
-          return sortDirection === "asc" ? aStr.localeCompare(bStr) : bStr.localeCompare(aStr);
-        })
-      : filteredPeople;
+          })
+        : filteredPeople;
 
     return sortedPeople;
   }, [hasData, searchValue, sortColumn, sortDirection]);
@@ -378,6 +378,7 @@ export const Table = () => {
       {/* TODO: Async sorting */}
 
       <VuiTable
+        data-testid="peopleTable"
         isLoading={isLoading}
         idField="id"
         rowDecorator={(person: Person) => ({ className: "testRowClass", "data-testid": person.name })}
@@ -393,9 +394,16 @@ export const Table = () => {
         onReload={onReload}
         search={search}
         customControls={
-          <VuiFormGroup label="Enter input" labelFor="input1">
-            <VuiTextInput id="input1" value="Text input" onChange={(event) => console.log(event.target.value)} />
-          </VuiFormGroup>
+          <VuiSelect
+            id="optionsList1"
+            options={[
+              { text: "All roles", value: "all" },
+              { text: "Guests", value: "guests" },
+              { text: "Staff", value: "staff" }
+            ]}
+            value="all"
+            onChange={(event) => console.log(`Selected ${event.target.value}`)}
+          />
         }
         isDisabled={isDisabled}
         bodyStyle={{

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -237,9 +237,32 @@ export const VuiTable = <T extends Row>({
     });
   }
 
+  const selectAllCheckboxProps = {
+    disabled: !isInteractive,
+    checked: isInteractive ? allRowsSelected : false,
+    onChange: () => {
+      let newSelectedRows: T[];
+
+      if (allRowsSelected) {
+        newSelectedRows = [];
+      } else {
+        newSelectedRows = rows.reduce((acc, row) => {
+          acc.push(row);
+          return acc;
+        }, [] as T[]);
+      }
+
+      onSelectRow?.(newSelectedRows);
+    },
+    "data-testid": "selectAllRowsCheckbox"
+  };
+
+  // @ts-expect-error data-testid doesn't exist on {}.
+  const { "data-testid": dataTestId, ...restProps } = rest;
+
   return (
     // @ts-expect-error React doesn't support inert yet
-    <div className="vuiTableWrapper" inert={isDisabled ? "" : null}>
+    <div className="vuiTableWrapper" inert={isDisabled ? "" : null} data-testid={dataTestId}>
       {isDisabled && <div className="vuiTableBlock" />}
       {(hasSearch ||
         customControls ||
@@ -248,27 +271,38 @@ export const VuiTable = <T extends Row>({
         <>
           <VuiFlexContainer
             spacing="s"
-            alignItems="end"
+            alignItems="center"
             className={isHeaderSticky ? "vuiTableStickyHeader" : undefined}
+            wrap
           >
+            {/* Responsive select-all checkbox */}
+            {onSelectRow && (
+              <VuiFlexItem grow={false} shrink={false} className="vuiTableHeader__responsiveSelectAllCheckbox">
+                <VuiCheckbox label="Select all" {...selectAllCheckboxProps} />
+              </VuiFlexItem>
+            )}
+
             {/* Bulk actions */}
             {selectedRows && selectedRows.length > 0 && hasBulkActions && (
               <VuiFlexItem grow={false} shrink={false}>
                 <VuiTableBulkActions selectedRows={selectedRows} actions={bulkActions} />
               </VuiFlexItem>
             )}
+
             {/* Search */}
             {hasSearch && (
               <VuiFlexItem grow={1} shrink={false}>
                 <VuiTextInput fullWidth {...search} />
               </VuiFlexItem>
             )}
+
             {/* Custom controls */}
             {customControls && (
               <VuiFlexItem grow={false} shrink={false}>
                 {customControls}
               </VuiFlexItem>
             )}
+
             {/* Reload */}
             {onReload && (
               <VuiFlexItem grow={1} shrink={false}>
@@ -285,31 +319,14 @@ export const VuiTable = <T extends Row>({
         </>
       )}
 
-      <table className={classes} {...rest}>
+      <table className={classes} {...restProps}>
         <thead>
           <tr>
             {/* Checkbox column */}
             {onSelectRow && (
               <th className="vuiTableHeaderSelect">
                 <VuiTableCell>
-                  <VuiCheckbox
-                    disabled={!isInteractive}
-                    checked={isInteractive ? allRowsSelected : false}
-                    onChange={() => {
-                      let newSelectedRows: T[];
-
-                      if (allRowsSelected) {
-                        newSelectedRows = [];
-                      } else {
-                        newSelectedRows = rows.reduce((acc, row) => {
-                          acc.push(row);
-                          return acc;
-                        }, [] as T[]);
-                      }
-
-                      onSelectRow(newSelectedRows);
-                    }}
-                  />
+                  <VuiCheckbox {...selectAllCheckboxProps} />
                 </VuiTableCell>
               </th>
             )}

--- a/src/lib/components/table/_index.scss
+++ b/src/lib/components/table/_index.scss
@@ -1,3 +1,6 @@
+$tableResponsiveBreakpointMedium: 800px;
+$tableResponsiveBreakpointSmall: 500px;
+
 .vuiTableWrapper {
   container-type: inline-size;
   width: 100%;
@@ -66,13 +69,21 @@
   }
 }
 
+.vuiTableHeader__responsiveSelectAllCheckbox {
+  display: none;
+}
+
 .vuiTableCell__label {
   font-size: $fontSizeSmall;
   font-weight: $labelFontWeight;
   color: var(--vui-color-label);
 }
 
-@container (width < 800px) {
+@container (width < #{$tableResponsiveBreakpointMedium}) {
+  .vuiTableHeader__responsiveSelectAllCheckbox {
+    display: flex;
+  }
+
   .vuiTable--responsive {
     thead {
       display: none;
@@ -140,7 +151,7 @@
   }
 }
 
-@container (width < 500px) {
+@container (width < #{$tableResponsiveBreakpointSmall}) {
   .vuiTable--responsive {
     tbody tr {
       grid-template-columns: 1fr;


### PR DESCRIPTION
Adding `data-testid` will apply it to the wrapper div, so you can use it to scope interaction with all child elements. The select-all checkbox has a built-in `data-testid`.

<img width="717" height="635" alt="image" src="https://github.com/user-attachments/assets/034131e9-3208-4ffa-9288-247713269f0f" />
