### PR TITLE
Make primary button focus state easier to see.

### DIFF
--- a/src/lib/components/button/buttonPrimary.scss
+++ b/src/lib/components/button/buttonPrimary.scss
@@ -4,6 +4,10 @@
   &:hover {
     box-shadow: $shadowSmallEnd;
   }
+
+  &:focus-visible {
+    outline-offset: 4px;
+  }
 }
 
 // Color


### PR DESCRIPTION
Fixes https://github.com/vectara/vectara-ui/issues/314

<img width="613" height="80" alt="image" src="https://github.com/user-attachments/assets/74d32841-4580-4771-ab18-61823c0f9fe6" />
