### PR TITLE
Fix formatting of code blocks.

### DIFF
--- a/src/docs/pages/text/Text.tsx
+++ b/src/docs/pages/text/Text.tsx
@@ -22,6 +22,10 @@ export const Text = () => (
               can get idea of the line-height.<sup>5</sup>
             </p>
 
+            <p>
+              Text with some <code>code</code>.
+            </p>
+
             <blockquote>
               <p>
                 A long paragraph of text that's inside a blockquote. This is to demonstrate how blockquotes look when
@@ -77,6 +81,15 @@ export const Text = () => (
 > In Markdown's ring.`}
               </code>
             </pre>
+
+            <code>
+              {`# Markdown's Grace
+
+*Italic* and **bold**,  
+\`Code\` unfolds,  
+> Quotes that sing,  
+> In Markdown's ring.`}
+            </code>
 
             <table>
               <thead>

--- a/src/lib/components/code/_index.scss
+++ b/src/lib/components/code/_index.scss
@@ -27,7 +27,7 @@
   padding: $sizeM $sizeL;
   background-color: var(--vui-color-light-shade);
   color: var(--vui-color-text);
-  font-family: "Roboto Mono", monospace;
+  font-family: var(--vui-font-family-monospace);
   // Ensure PrismJS components wrap their lines.
   word-wrap: break-word !important;
   // Ensure PrismJS components wrap their lines instead of making the container super-wide.

--- a/src/lib/components/context/Theme.ts
+++ b/src/lib/components/context/Theme.ts
@@ -3,6 +3,7 @@ import { ColorTranslator } from "colortranslator";
 export type Theme = {
   // Font
   fontFamily?: string;
+  fontFamilyMonospace?: string;
 
   // Semantic colors
   colorAccentShade?: string;
@@ -76,6 +77,8 @@ export type Theme = {
 const fontFamily = `-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans",
   "Droid Sans", "Helvetica Neue", sans-serif`;
 
+const fontFamilyMonospace = '"Roboto Mono", monospace';
+
 export const toRgba = (hex: string, alpha: number) => {
   return new ColorTranslator(hex, { legacyCSS: true }).setA(alpha).RGBA;
 };
@@ -130,6 +133,7 @@ const colorBorderLightShade = "#e3e4f3";
 export const LIGHT_THEME: Theme = {
   // Font
   fontFamily,
+  fontFamilyMonospace,
 
   // Semantic colors
   colorAccentShade,
@@ -233,6 +237,7 @@ export const toStyle = (theme: Theme) => {
   const vars = {
     // Font
     "--vui-font-family": theme.fontFamily,
+    "--vui-font-family-monospace": theme.fontFamilyMonospace,
 
     // Semantic colors
     "--vui-color-accent-shade": theme.colorAccentShade,

--- a/src/lib/components/typography/_text.scss
+++ b/src/lib/components/typography/_text.scss
@@ -41,32 +41,40 @@ $textRhythm: $sizeM;
 
   pre:not(:has(> code)),
   code {
+    display: block;
+    padding: $sizeXs $sizeS;
     background-color: var(--vui-color-light-shade);
-    padding: $sizeXxxs $sizeXxs;
+    font-family: var(--vui-font-family-monospace);
+    border-radius: $sizeXs;
+    margin-bottom: $textRhythm;
   }
 
   pre:has(> code) {
     display: block;
-    background-color: var(--vui-color-light-shade);
     padding: $sizeXs $sizeS;
+    background-color: var(--vui-color-light-shade);
     margin-bottom: $textRhythm;
     border-radius: $sizeXs;
+    font-family: var(--vui-font-family-monospace);
   }
 
   pre > code {
     word-wrap: break-word;
     word-break: break-word;
     white-space: pre-wrap;
+    font-family: var(--vui-font-family-monospace);
+    margin-bottom: 0;
   }
 
-  p > pre:only-child,
-  p > code:only-child {
-    display: block;
-    padding: $sizeXs $sizeS;
+  p > pre,
+  p > code {
+    display: inline;
+    padding: $sizeXxxs $sizeXxs;
     border: none;
     border-radius: $sizeXs;
     overflow: auto;
     background-color: var(--vui-color-light-shade);
+    font-family: var(--vui-font-family-monospace);
   }
 
   blockquote {
@@ -135,6 +143,7 @@ $textRhythm: $sizeM;
   code,
   pre {
     font-size: $fontSize * 0.85;
+    font-family: var(--vui-font-family-monospace);
   }
 
   h1 {


### PR DESCRIPTION
Now they appear correctly in various permutations:
* Standalone
* Within p tags
* Within pre tags

<img width="813" height="748" alt="image" src="https://github.com/user-attachments/assets/38bd40ce-be77-4c07-ad78-90ccd60762e1" />
