### PR TITLE
Add api for components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "13.12.0",
+  "version": "13.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "13.12.0",
+      "version": "13.14.0",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/src/docs/Page.tsx
+++ b/src/docs/Page.tsx
@@ -3,10 +3,11 @@ import { BiRightArrowAlt, BiLeftArrowAlt } from "react-icons/bi";
 import { VuiIconButton, VuiFlexContainer, VuiFlexItem, VuiIcon, VuiTitle, VuiAppContent, VuiSpacer } from "../lib";
 import { Page as PageType, paths } from "./pages";
 import { Example } from "./components/Example";
+import { Api } from "./components/Api";
 import React from "react";
 
 export const Page = ({ page }: { page: PageType }) => {
-  const { name, example, examples } = page;
+  const { name, example, examples, api } = page;
   const location = useLocation();
   const navigate = useNavigate();
   const currentPageIndex = paths.list.findIndex((page) => page.path === location.pathname);
@@ -74,6 +75,13 @@ export const Page = ({ page }: { page: PageType }) => {
           ))
         )}
       </>
+
+      {api && api.length > 0 && (
+        <>
+          <VuiSpacer size="l" />
+          <Api components={api} />
+        </>
+      )}
     </VuiAppContent>
   );
 };

--- a/src/docs/components/Api.tsx
+++ b/src/docs/components/Api.tsx
@@ -1,0 +1,66 @@
+import { VuiCode, VuiInfoTable, VuiSpacer, VuiTitle, VuiText } from "../../lib";
+
+export type PropInfo = {
+  name: string;
+  type: string;
+  required?: boolean;
+  default?: string;
+  description: string;
+};
+
+export type ComponentApi = {
+  name: string;
+  props: PropInfo[];
+};
+
+type Props = {
+  components: ComponentApi[];
+};
+
+export const Api = ({ components }: Props) => {
+  const columns = [
+    { name: "prop", render: "Prop", width: "150px" },
+    { name: "type", render: "Type", width: "200px" },
+    { name: "required", render: "Required", width: "80px" },
+    { name: "default", render: "Default", width: "120px" },
+    { name: "description", render: "Description" }
+  ];
+
+  return (
+    <>
+      <VuiTitle size="s">
+        <h3>API</h3>
+      </VuiTitle>
+
+      <VuiSpacer size="m" />
+
+      {components.map(({ name, props }) => {
+        const rows = props.map((prop) => ({
+          values: {
+            prop: { render: <VuiCode language="tsx">{prop.name}</VuiCode> },
+            type: { render: <VuiCode language="tsx">{prop.type}</VuiCode> },
+            required: { render: <VuiText>{prop.required ? "Yes" : "No"}</VuiText> },
+            default: {
+              render: prop.default ? <VuiCode language="tsx">{prop.default}</VuiCode> : <VuiText>-</VuiText>
+            },
+            description: { render: <VuiText>{prop.description}</VuiText> }
+          }
+        }));
+
+        return (
+          <div key={name}>
+            <VuiTitle size="xs">
+              <h4>{name}</h4>
+            </VuiTitle>
+
+            <VuiSpacer size="s" />
+
+            <VuiInfoTable columns={columns} rows={rows} isHeaderVisible padding="s" />
+
+            <VuiSpacer size="l" />
+          </div>
+        );
+      })}
+    </>
+  );
+};

--- a/src/docs/pages.tsx
+++ b/src/docs/pages.tsx
@@ -69,8 +69,16 @@ import { validation } from "./pages/validation";
 // Utils
 import { truncate } from "./pages/truncate";
 
+import { ComponentApi } from "./components/Api";
+
 type Category = { name: string; pages: Page[] };
-export type Page = { name: string; path: string; examples?: Array<Example & { name: string }>; example?: Example };
+export type Page = {
+  name: string;
+  path: string;
+  examples?: Array<Example & { name: string }>;
+  example?: Example;
+  api?: ComponentApi[];
+};
 type Example = { component: React.ReactNode; source: string };
 
 export const categories: Category[] = [

--- a/src/docs/pages/button/index.tsx
+++ b/src/docs/pages/button/index.tsx
@@ -4,6 +4,7 @@ import { Icons } from "./Icons";
 import { IconButton } from "./IconButton";
 import { Link } from "./Link";
 import { Submit } from "./Submit";
+import { ComponentApi } from "../../components/Api";
 
 const ColorsSource = require("!!raw-loader!./Colors");
 const SizesSource = require("!!raw-loader!./Sizes");
@@ -12,9 +13,156 @@ const IconButtonSource = require("!!raw-loader!./IconButton");
 const LinkSource = require("!!raw-loader!./Link");
 const SubmitSource = require("!!raw-loader!./Submit");
 
+const api: ComponentApi[] = [
+  {
+    name: "VuiButtonPrimary",
+    props: [
+      {
+        name: "color",
+        type: '"accent" | "primary" | "success" | "danger" | "warning" | "neutral" | "subdued"',
+        required: true,
+        description: "The color scheme of the button"
+      },
+      {
+        name: "size",
+        type: '"xs" | "s" | "m" | "l"',
+        default: '"m"',
+        description: "The size of the button"
+      },
+      {
+        name: "children",
+        type: "ReactNode",
+        description: "The content to display inside the button"
+      },
+      {
+        name: "icon",
+        type: "ReactElement",
+        description: "An optional icon to display alongside the button text"
+      },
+      {
+        name: "iconSide",
+        type: '"left" | "right"',
+        default: '"left"',
+        description: "Which side of the button text to display the icon"
+      },
+      {
+        name: "fullWidth",
+        type: "boolean",
+        description: "Whether the button should take up the full width of its container"
+      },
+      {
+        name: "isSelected",
+        type: "boolean",
+        description: "Whether the button is in a selected state"
+      },
+      {
+        name: "isDisabled",
+        type: "boolean",
+        description: "Whether the button is disabled"
+      },
+      {
+        name: "isLoading",
+        type: "boolean",
+        description: "Whether to show a loading spinner"
+      },
+      {
+        name: "href",
+        type: "string",
+        description: "If provided, renders the button as a link"
+      },
+      {
+        name: "target",
+        type: "string",
+        description: "The target attribute for the link (when href is provided)"
+      },
+      {
+        name: "onClick",
+        type: "(event: MouseEvent) => void",
+        description: "Click handler for the button"
+      },
+      {
+        name: "isSubmit",
+        type: "boolean",
+        description: 'Whether the button should submit a form (type="submit")'
+      }
+    ]
+  },
+  {
+    name: "VuiButtonSecondary",
+    props: [
+      {
+        name: "color",
+        type: '"accent" | "primary" | "success" | "danger" | "warning" | "neutral" | "subdued"',
+        required: true,
+        description: "The color scheme of the button"
+      },
+      {
+        name: "size",
+        type: '"xs" | "s" | "m" | "l"',
+        default: '"m"',
+        description: "The size of the button"
+      },
+      {
+        name: "children",
+        type: "ReactNode",
+        description: "The content to display inside the button"
+      },
+      {
+        name: "icon",
+        type: "ReactElement",
+        description: "An optional icon to display alongside the button text"
+      },
+      {
+        name: "isDisabled",
+        type: "boolean",
+        description: "Whether the button is disabled"
+      },
+      {
+        name: "onClick",
+        type: "(event: MouseEvent) => void",
+        description: "Click handler for the button"
+      }
+    ]
+  },
+  {
+    name: "VuiIconButton",
+    props: [
+      {
+        name: "icon",
+        type: "ReactElement",
+        required: true,
+        description: "The icon to display"
+      },
+      {
+        name: "color",
+        type: '"accent" | "primary" | "success" | "danger" | "warning" | "neutral" | "subdued"',
+        required: true,
+        description: "The color scheme of the button"
+      },
+      {
+        name: "size",
+        type: '"xs" | "s" | "m" | "l"',
+        default: '"m"',
+        description: "The size of the button"
+      },
+      {
+        name: "isDisabled",
+        type: "boolean",
+        description: "Whether the button is disabled"
+      },
+      {
+        name: "onClick",
+        type: "(event: MouseEvent) => void",
+        description: "Click handler for the button"
+      }
+    ]
+  }
+];
+
 export const button = {
   name: "Button",
   path: "/button",
+  api,
   examples: [
     {
       name: "Colors",


### PR DESCRIPTION
# feat: add component's API for easy access to prop definitions.

### Screenshots

<img width="1469" height="870" alt="Screenshot 2026-01-14 at 2 56 27 PM" src="https://github.com/user-attachments/assets/bc3ee9e9-73bb-4ae4-a83a-26215b2c4a40" />


