### PR TITLE
feat: extend anchor positions for popover

### DIFF
--- a/src/docs/pages/drawer/PrimaryDrawer.tsx
+++ b/src/docs/pages/drawer/PrimaryDrawer.tsx
@@ -9,6 +9,7 @@ import {
   VuiToggle
 } from "../../../lib";
 import { BiInfoCircle } from "react-icons/bi";
+import { FormGroup } from "../searchSelect/FormGroup";
 
 export const PrimaryDrawer = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -181,6 +182,9 @@ export const PrimaryDrawer = () => {
             </tbody>
           </table>
         </VuiText>
+        <VuiSpacer size="l" />
+        <FormGroup />
+        <VuiSpacer size="l" />
       </VuiDrawer>
     </>
   );

--- a/src/docs/pages/searchSelect/FormGroup.tsx
+++ b/src/docs/pages/searchSelect/FormGroup.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { VuiFormGroup, VuiSearchSelect, VuiTextInput } from "../../../lib";
+import { AnchorSide, VuiFormGroup, VuiSearchSelect, VuiSelect, VuiSpacer, VuiText, VuiTextInput } from "../../../lib";
 
 const options = [
   { value: "a", label: "Caffeine-free" },
@@ -45,7 +45,33 @@ export const FormGroup = () => {
   const [searchValue, setSearchValue] = useState<string>("");
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
 
+    const [anchorSide, setAnchorSide] = useState<AnchorSide | undefined>("left");
+  const anchorOptions = [
+    { text: "Left", value: "left" },
+    { text: "Right", value: "right" },
+    { text: "Right Up", value: "rightUp" },
+    { text: "Left Up", value: "leftUp" },
+    { text: "Up Left", value: "upLeft" },
+    { text: "Up Right", value: "upRight" }
+  ];
+
+
   return (
+    <>
+    <VuiText size="s">
+      <p>
+        <strong>
+          Popover position
+        </strong>
+      </p>
+    </VuiText>
+    <VuiSpacer size="xs" />
+     <VuiSelect
+        options={anchorOptions}
+        value={anchorSide}
+        onChange={(event) => setAnchorSide(event.target.value as AnchorSide)}
+      />
+      <VuiSpacer size="l" />
     <VuiFormGroup label="Search select" labelFor="searchSelect">
       <VuiSearchSelect
         title="Choose one or more"
@@ -58,10 +84,11 @@ export const FormGroup = () => {
         }}
         selectedOptions={selectedOptions}
         options={options}
-        anchorSide="left"
-      >
+        anchorSide={anchorSide}
+        >
         <VuiTextInput fullWidth color="neutral" id="searchSelect" value={humanizeOptions(selectedOptions)} />
       </VuiSearchSelect>
     </VuiFormGroup>
+        </>
   );
 };

--- a/src/lib/components/popover/Popover.tsx
+++ b/src/lib/components/popover/Popover.tsx
@@ -4,7 +4,7 @@ import { VuiPortal } from "../portal/Portal";
 import { FocusOn } from "react-focus-on";
 import { VuiItemsInput, VuiNumberInput, VuiTextInput } from "../form";
 
-export type AnchorSide = "left" | "right" | "rightUp";
+export type AnchorSide = "left" | "right" | "rightUp" | "leftUp" | "upLeft" | "upRight";
 
 export type Props = {
   button: React.ReactElement;
@@ -36,6 +36,26 @@ const calculatePopoverPosition = (button: HTMLElement | null, anchorSide: Anchor
     // TODO: Hardcoded offset is intended for use with VuiAppSideNav. Extract this into a configurable prop.
     const adjustedLeft = left + width + 26;
     return { top: `${adjustedTop}px`, left: `${adjustedLeft}px` };
+  }
+
+  if (anchorSide === "leftUp") {
+    // Anchor popover to the left side of the button, extending upwards.
+    const adjustedTop = top + height + document.documentElement.scrollTop;
+    const adjustedRight = document.documentElement.clientWidth - left + 26;
+    return { top: `${adjustedTop}px`, right: `${adjustedRight}px` };
+  }
+
+  if (anchorSide === "upLeft") {
+    // Anchor popover above the button, aligned to the left edge.
+    const adjustedBottom = document.documentElement.clientHeight - top + 2;
+    return { bottom: `${adjustedBottom}px`, left: `${left}px` };
+  }
+
+  if (anchorSide === "upRight") {
+    // Anchor popover above the button, aligned to the right edge.
+    const adjustedBottom = document.documentElement.clientHeight - top + 2;
+    const adjustedRight = document.documentElement.clientWidth - right;
+    return { bottom: `${adjustedBottom}px`, right: `${adjustedRight}px` };
   }
 
   const adjustedTop = bottom + 2 + document.documentElement.scrollTop;
@@ -152,7 +172,10 @@ export const VuiPopover = ({
 
   const classes = classNames("vuiPopover", className, {
     "vuiPopover-isLoaded": showTransition,
-    "vuiPopover--rightUp": anchorSide === "rightUp"
+    "vuiPopover--rightUp": anchorSide === "rightUp",
+    "vuiPopover--leftUp": anchorSide === "leftUp",
+    "vuiPopover--upLeft": anchorSide === "upLeft",
+    "vuiPopover--upRight": anchorSide === "upRight"
   });
 
   const contentClasses = classNames("vuiPopoverContent", {

--- a/src/lib/components/popover/_index.scss
+++ b/src/lib/components/popover/_index.scss
@@ -16,8 +16,14 @@
   overflow: visible;
 }
 
-.vuiPopover--rightUp {
+.vuiPopover--rightUp,
+.vuiPopover--leftUp {
   transform: translateY(-100%) !important;
+}
+
+.vuiPopover--upLeft,
+.vuiPopover--upRight {
+  transform: translateY($sizeXs);
 }
 
 .vuiPopover-isLoaded {


### PR DESCRIPTION
# feat: extend anchor positions for the popover

### Summary
**Problem:** When the `SearchSelect` component is rendered inside a portal, overflow scrolling is not activated correctly, causing content to be clipped (see image below).

This PR extends the available popover anchor positions to work around the layout constraints.

### Screenshots:

#### overflow issue
<img width="1469" height="869" alt="image" src="https://github.com/user-attachments/assets/6a865f64-de3b-4830-bb76-539495223ccd" />

#### new positions

#### Left up
<img width="1468" height="868" alt="Screenshot 2026-01-14 at 4 32 32 PM" src="https://github.com/user-attachments/assets/92a67c94-716b-4dc7-8127-1cf667697a41" />

#### Up left
<img width="1470" height="869" alt="Screenshot 2026-01-14 at 4 32 46 PM" src="https://github.com/user-attachments/assets/6a002e3a-35c0-4142-bd7a-b207545840e1" />

#### Up right
<img width="1468" height="869" alt="Screenshot 2026-01-14 at 4 38 11 PM" src="https://github.com/user-attachments/assets/12956acd-5a98-4cbf-926e-bd91805d7cb9" />



