### PR TITLE
Fix bug in which prismjs sometimes doesn't set the required code styles for scrolling.

### DIFF
--- a/src/lib/components/code/_index.scss
+++ b/src/lib/components/code/_index.scss
@@ -19,6 +19,8 @@
   max-height: inherit;
   background-color: var(--vui-color-light-shade) !important;
   border-radius: $sizeXxs;
+  // Ensure scrolling in case prism doesn't apply the correct styles.
+  overflow: auto;
 }
 
 .vuiCode {


### PR DESCRIPTION
Typically prism.js will apply a class that enables scrolling:

<img width="660" height="585" alt="image" src="https://github.com/user-attachments/assets/70d593e0-5a48-4680-a0f4-5e0abafe5394" />

However we've seen cases where this doesn't happen, causing the code text content to overflow the container. This change provides a backstop to fix this edge case.