### PR TITLE
Fix styling of code elements in VuiText.

### DIFF
--- a/src/docs/pages/text/Text.tsx
+++ b/src/docs/pages/text/Text.tsx
@@ -95,6 +95,20 @@ export const Text = () => (
 > In Markdown's ring.`}
             </code>
 
+            <ol>
+              <li>
+                Choose:
+                <ul>
+                  <li>
+                    <strong>Option A:</strong> <code>EXECUTE</code>
+                  </li>
+                  <li>
+                    <strong>Option B:</strong> <code>ABORT</code>
+                  </li>
+                </ul>
+              </li>
+            </ol>
+
             <table>
               <thead>
                 <tr>

--- a/src/lib/components/typography/_text.scss
+++ b/src/lib/components/typography/_text.scss
@@ -39,6 +39,7 @@ $textRhythm: $sizeM;
     margin-bottom: $textRhythm;
   }
 
+  // Default block styles for code and pre.
   pre:not(:has(> code)),
   code {
     display: block;
@@ -59,22 +60,63 @@ $textRhythm: $sizeM;
   }
 
   pre > code {
+    display: block;
     word-wrap: break-word;
     word-break: break-word;
     white-space: pre-wrap;
     font-family: var(--vui-font-family-monospace);
     margin-bottom: 0;
+    padding: 0;
+    background-color: transparent;
   }
 
-  p pre,
-  p code {
-    display: inline;
-    padding: $sizeXxxs $sizeXxs;
-    border: none;
-    border-radius: $sizeXs;
-    overflow: auto;
-    background-color: var(--vui-color-light-shade);
-    font-family: var(--vui-font-family-monospace);
+  // Inline styles when nested in text-like elements.
+  strong,
+  b,
+  em,
+  i,
+  p,
+  li,
+  td,
+  th,
+  span,
+  label,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    > pre,
+    > code {
+      display: inline;
+      padding: $sizeXxxs $sizeXxs;
+      border-radius: $sizeXs;
+      overflow: auto;
+      background-color: var(--vui-color-light-shade);
+      font-family: var(--vui-font-family-monospace);
+      margin-bottom: 0;
+    }
+  }
+
+  // Block styles when nested in block-like elements.
+  div,
+  blockquote,
+  section,
+  article,
+  aside,
+  main,
+  nav,
+  header,
+  footer {
+    > pre:not(:has(> code)),
+    > code {
+      display: block;
+    }
+
+    > pre:has(> code) {
+      display: block;
+    }
   }
 
   blockquote {


### PR DESCRIPTION
Prompt:

```
Look at the CSS styles for pre and code in src/lib/components/typography/_text.scss. Fix these styles so that:

* If nested within a "text-like" element, like <p>, <li>, and any others you can suggest, <code> and <pre> are treated as inline elements.
* If nested within a "block-like" element, like <div>, <blockquote>, and any others you can suggest, <code> and <pre> are treated as block elements.
* If a <code> is nested within a <pre>, it's treated as a block element.
```

Key changes:

  1. Default block styles - Both code and pre are block elements by default
  2. Inline in text-like elements - When nested directly within text-like elements (p, li, td, th, span, label, h1-h6), they become inline with smaller padding
  3. Block in block-like elements - Explicit block styles when nested in block-like elements (div, blockquote, section, article, aside, main, nav, header, footer)
  4. Code inside pre is always block - Added explicit display: block to pre > code, with transparent background and no padding since the parent pre provides those styles

  The CSS now uses the > child combinator to ensure these rules only apply to direct children, preventing unwanted cascading effects. This approach provides clear, maintainable styling that adapts based on the parent element's semantic purpose.

<img width="1149" height="945" alt="image" src="https://github.com/user-attachments/assets/547536a7-8283-476d-9d6b-d1358e450dc8" />
