### PR TITLE
Add allowUndefined prop to VuiNumberInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "15.5.2",
+  "version": "15.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "15.5.2",
+      "version": "15.7.0",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "15.6.5",
+  "version": "15.7.0",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",

--- a/src/lib/components/form/input/NumberInput.tsx
+++ b/src/lib/components/form/input/NumberInput.tsx
@@ -7,10 +7,14 @@ type Props = Omit<BasicInputProps, "onChange"> & {
   max?: number;
   min?: number;
   step?: number;
+  // By default, an empty input calls onChange with 0. When true, an empty
+  // input calls onChange with undefined instead, letting consumers distinguish
+  // "no value" from "zero."
+  allowUndefined?: boolean;
 };
 
 export const VuiNumberInput = forwardRef<HTMLInputElement | null, Props>(
-  ({ value, onChange, max, min, step, ...rest }: Props, ref) => {
+  ({ value, onChange, max, min, step, allowUndefined, ...rest }: Props, ref) => {
     const [localValue, setLocalValue] = useState<number | undefined>(value);
 
     // This is a hacky solution to the number input misbehaving on Firefox.
@@ -24,18 +28,21 @@ export const VuiNumberInput = forwardRef<HTMLInputElement | null, Props>(
     // For some reason, using a useState hook to store the value doesn't have
     // this problem.
     useEffect(() => {
-      // Reflect the upstream value when it changes. Ignore 0
-      // because that indicates the user has entered a decimal point.
-      if (value !== 0) {
+      // Reflect the upstream value when it changes. Ignore 0 because that
+      // indicates the user has entered a decimal point (Firefox workaround).
+      // When allowUndefined is on, also ignore undefined — otherwise the
+      // parent reflecting undefined back would clear the input mid-typing.
+      if (value !== 0 && !(allowUndefined && value === undefined)) {
         setLocalValue(value);
       }
     }, [value]);
 
-    // Part of the hacky solution above.
+    // Propagate localValue changes upstream. Without allowUndefined, an
+    // undefined localValue (empty input) is coerced to 0 so existing
+    // consumers always receive a number. With allowUndefined, undefined
+    // passes through so consumers can treat empty as "no value."
     useEffect(() => {
-      // Set value locally so an undefined value doesn't reset it to 0.
-      // Pass the value upstream, e.g. so it can be persisted.
-      onChange(localValue ?? 0);
+      onChange(allowUndefined ? localValue : (localValue ?? 0));
     }, [localValue]);
 
     const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/lib/components/form/input/NumberInput.tsx
+++ b/src/lib/components/form/input/NumberInput.tsx
@@ -32,7 +32,8 @@ export const VuiNumberInput = forwardRef<HTMLInputElement | null, Props>(
       // indicates the user has entered a decimal point (Firefox workaround).
       // When allowUndefined is on, also ignore undefined — otherwise the
       // parent reflecting undefined back would clear the input mid-typing.
-      if (value !== 0 && !(allowUndefined && value === undefined)) {
+      const isUndefined = !(allowUndefined && value === undefined);
+      if (value !== 0 && isUndefined) {
         setLocalValue(value);
       }
     }, [value]);
@@ -42,7 +43,7 @@ export const VuiNumberInput = forwardRef<HTMLInputElement | null, Props>(
     // consumers always receive a number. With allowUndefined, undefined
     // passes through so consumers can treat empty as "no value."
     useEffect(() => {
-      onChange(allowUndefined ? localValue : (localValue ?? 0));
+      onChange(allowUndefined ? localValue : localValue ?? 0);
     }, [localValue]);
 
     const onChangeValue = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary
- `VuiNumberInput` coerces empty inputs to `0` in `onChange`, making it impossible for consumers to distinguish "no value" from "zero."
- Adds an opt-in `allowUndefined` prop that passes `undefined` through instead, while preserving the existing Firefox decimal-point workaround.
- Fully backward-compatible: default behavior is unchanged.

## Test plan
- [ ] Verify existing consumers behave identically (prop defaults to `false`).
- [ ] Pass `allowUndefined` and confirm clearing the input yields `undefined`, not `0`.
- [ ] Test Firefox decimal-point typing (e.g. "1.05") still works correctly with `allowUndefined` on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)