### PR TITLE
fix: hide checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "15.7.0",
+  "version": "15.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "15.7.0",
+      "version": "15.7.1",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "15.7.0",
+  "version": "15.7.1",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -347,8 +347,8 @@ export const VuiTable = <T extends Row>({
             className={isHeaderSticky ? "vuiTableStickyHeader" : undefined}
             wrap
           >
-            {/* Responsive select-all checkbox */}
-            {onSelectRow && (
+            {/* Responsive select-all checkbox - shown when isResponsive is true. */}
+            {onSelectRow && isResponsive && (
               <VuiFlexItem grow={false} shrink={false} className="vuiTableHeader__responsiveSelectAllCheckbox">
                 <VuiCheckbox label="Select all" {...selectAllCheckboxProps} />
               </VuiFlexItem>


### PR DESCRIPTION
## Summary

Guard the above-table "Select all" checkbox behind `isResponsive` so it only renders when the table can actually collapse into its card-stacked layout.

### Problem 

Duplicate select all checkbox above the table, when isResponsive is `false`
<img width="449" height="150" alt="Screenshot 2026-04-21 at 8 15 42 PM" src="https://github.com/user-attachments/assets/b84879a9-a05f-4439-96e6-07b62a334897" />

### Fixed 

<img width="454" height="176" alt="Screenshot 2026-04-21 at 8 15 22 PM" src="https://github.com/user-attachments/assets/1e30d784-b164-4521-bf99-0e4f1b94934c" />
