### PR TITLE
Make label optional for form group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "15.7.1",
+  "version": "16.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "15.7.1",
+      "version": "16.0.1",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "16.0.0",
+  "version": "16.0.1",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",

--- a/src/docs/pages/formGroup/NoLabel.tsx
+++ b/src/docs/pages/formGroup/NoLabel.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { VuiFormGroup, VuiSpacer, VuiTextInput, VuiToggle } from "../../../lib";
+
+export const NoLabel = () => {
+  const [showError, setShowError] = useState(false);
+
+  return (
+    <>
+      <VuiToggle label="Show error message" onChange={(e) => setShowError(e.target.checked)} />
+
+      <VuiSpacer size="m" />
+
+      <VuiFormGroup errors={showError ? ["This is an error message."] : []}>
+        <VuiTextInput value="Text input" onChange={() => undefined} />
+      </VuiFormGroup>
+    </>
+  );
+};

--- a/src/docs/pages/formGroup/index.tsx
+++ b/src/docs/pages/formGroup/index.tsx
@@ -1,9 +1,11 @@
 import { FormGroup } from "./FormGroup";
 import { NonFormElement } from "./NonFormElement";
+import { NoLabel } from "./NoLabel";
 import { Size } from "./Size";
 
 const FormGroupSource = require("!!raw-loader!./FormGroup");
 const NonFormElementSource = require("!!raw-loader!./NonFormElement");
+const NoLabelSource = require("!!raw-loader!./NoLabel");
 const SizeSource = require("!!raw-loader!./Size");
 
 export const formGroup = {
@@ -19,6 +21,11 @@ export const formGroup = {
       name: "Non-form elements",
       component: <NonFormElement />,
       source: NonFormElementSource.default.toString()
+    },
+    {
+      name: "Without label",
+      component: <NoLabel />,
+      source: NoLabelSource.default.toString()
     },
     {
       name: "Label size",

--- a/src/lib/components/formGroup/FormGroup.tsx
+++ b/src/lib/components/formGroup/FormGroup.tsx
@@ -12,8 +12,8 @@ import { VuiSelect } from "../form/select/Select";
 const VALIDATION_ALLOWLIST = [VuiTextInput, VuiNumberInput, VuiTextArea, VuiSelect] as const;
 
 type Props = {
-  labelFor: string;
-  label: string;
+  labelFor?: string;
+  label?: string;
   labelSize?: "s" | "xs";
   children: React.ReactElement;
   helpText?: React.ReactNode;
@@ -56,7 +56,7 @@ export const VuiFormGroup = ({ children, labelFor, helpText, label, labelSize = 
   }
 
   const cloneProps: {
-    id: string;
+    id?: string;
     required: boolean | undefined;
     isInvalid?: boolean;
   } = {
@@ -75,12 +75,16 @@ export const VuiFormGroup = ({ children, labelFor, helpText, label, labelSize = 
 
   return (
     <div>
-      <VuiLabel labelFor={labelFor} size={labelSize}>
-        {label}
-        {isRequired && " (required)"}
-      </VuiLabel>
+      {label && (
+        <>
+          <VuiLabel labelFor={labelFor} size={labelSize}>
+            {label}
+            {isRequired && " (required)"}
+          </VuiLabel>
 
-      <VuiSpacer size={labelSize === "s" ? "xs" : "xxs"} />
+          <VuiSpacer size={labelSize === "s" ? "xs" : "xxs"} />
+        </>
+      )}
 
       {helpText && (
         <>


### PR DESCRIPTION
# feat: make label optional for form group

## Summary

Make label optional for form group. This enables using form group for leveraging error text without hacking the UI. See [convo](https://github.com/vectara/platform/pull/5120#discussion_r3124657874).

<img width="319" height="240" alt="image" src="https://github.com/user-attachments/assets/96d20385-61e0-4de6-97b9-b001c4fb0284" />
