### PR TITLE
fix screen block z-indexes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "16.0.1",
+  "version": "16.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "16.0.1",
+      "version": "16.1.1",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "16.1.0",
+  "version": "16.1.1",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",

--- a/src/docs/pages/drawer/PrimaryDrawer.tsx
+++ b/src/docs/pages/drawer/PrimaryDrawer.tsx
@@ -5,6 +5,7 @@ import {
   VuiButtonSecondary,
   VuiDrawer,
   VuiFlexContainer,
+  VuiModal,
   VuiNotifications,
   VuiSpacer,
   VuiText,
@@ -16,6 +17,7 @@ import { FormGroup } from "../searchSelect/FormGroup";
 export const PrimaryDrawer = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [hasFooter, setHasFooter] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   return (
     <>
@@ -63,6 +65,12 @@ export const PrimaryDrawer = () => {
           }}
         >
           Add notification
+        </VuiButtonSecondary>
+
+        <VuiSpacer size="m" />
+
+        <VuiButtonSecondary color="primary" onClick={() => setIsModalOpen(true)}>
+          Open modal from drawer
         </VuiButtonSecondary>
 
         <VuiSpacer size="m" />
@@ -202,6 +210,15 @@ export const PrimaryDrawer = () => {
         <FormGroup />
         <VuiSpacer size="l" />
       </VuiDrawer>
+
+      <VuiModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} title="I'm a modal inside a drawer!">
+        <VuiText>
+          <p>
+            This modal is rendered inside the drawer. It demonstrates that you can have multiple layers of overlays and
+            that the focus management and scroll locking still work as expected.
+          </p>
+        </VuiText>
+      </VuiModal>
 
       <VuiNotifications />
     </>

--- a/src/lib/components/screenBlock/_index.scss
+++ b/src/lib/components/screenBlock/_index.scss
@@ -17,11 +17,11 @@
   opacity: 0;
 }
 
-.vuiScreenBlock--default {
+.vuiScreenBlock.vuiScreenBlock--default {
   z-index: $screenBlockZIndex;
 }
 
-.vuiScreenBlock--modal {
+.vuiScreenBlock.vuiScreenBlock--modal {
   z-index: $modalZIndex;
 }
 


### PR DESCRIPTION
[slack convo](https://vectara.slack.com/archives/C055K01MB0E/p1777313834753319).

## Problem

The drawer renders above the modal (see image). This happens because the `.vuiScreenBlock` z-index from `@vectara/react-search` overrides z-index for screen block classes in `@vectara/vectara-ui`.

<img width="321" height="452" alt="image" src="https://github.com/user-attachments/assets/bfff6da0-d7d7-4263-b1fd-ae2e41ef584f" />

<img width="450" height="450" alt="image" src="https://github.com/user-attachments/assets/a66941c3-28ea-4f9f-a5a6-a6db4e441c26" />


## Solution

Increased the specificity of classes in `@vectara/vectara-ui`. 

## Screenshots - tested solution

<img width="1525" height="883" alt="image" src="https://github.com/user-attachments/assets/00d2dd0e-0afa-4cfa-a9ee-aede25674a7f" />


## Next:

- [ ] Update https://github.com/vectara/react-search to use `@vectara/vectara-ui`.