### PR TITLE
Add indeterminate state to VuiToggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 **Non-breaking changes**
 
-...
+- `VuiToggle` now renders an indeterminate "unset" state when `checked` is `undefined` (knob centered, lighter background). Existing call sites that pass an explicit `boolean` are unaffected; sites that previously omitted `checked` and relied on it rendering as off will now render as indeterminate.
 
 **Breaking changes**
 

--- a/src/docs/pages/toggle/Toggle.tsx
+++ b/src/docs/pages/toggle/Toggle.tsx
@@ -1,8 +1,27 @@
 import { useState } from "react";
-import { VuiToggle } from "../../../lib";
+import { VuiButtonSecondary, VuiFlexContainer, VuiFlexItem, VuiSpacer, VuiToggle } from "../../../lib";
 
 export const Toggle = () => {
   const [isChecked, setIsChecked] = useState(false);
+  // `undefined` renders the toggle in the indeterminate "unset" state.
+  const [maybeChecked, setMaybeChecked] = useState<boolean | undefined>(undefined);
 
-  return <VuiToggle checked={isChecked} onChange={(e) => setIsChecked(e.target.checked)} label="Caffeinate workers" />;
+  return (
+    <>
+      <VuiToggle checked={isChecked} onChange={(e) => setIsChecked(e.target.checked)} label="Caffeinate workers" />
+
+      <VuiSpacer size="m" />
+
+      <VuiFlexContainer alignItems="center" spacing="m">
+        <VuiFlexItem grow={false}>
+          <VuiToggle checked={maybeChecked} onChange={(e) => setMaybeChecked(e.target.checked)} label="Auto-detect (unset by default)" />
+        </VuiFlexItem>
+        <VuiFlexItem grow={false}>
+          <VuiButtonSecondary size="s" onClick={() => setMaybeChecked(undefined)}>
+            Reset
+          </VuiButtonSecondary>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    </>
+  );
 };

--- a/src/docs/pages/toggle/Toggle.tsx
+++ b/src/docs/pages/toggle/Toggle.tsx
@@ -17,7 +17,7 @@ export const Toggle = () => {
           <VuiToggle checked={maybeChecked} onChange={(e) => setMaybeChecked(e.target.checked)} label="Auto-detect (unset by default)" />
         </VuiFlexItem>
         <VuiFlexItem grow={false}>
-          <VuiButtonSecondary size="s" onClick={() => setMaybeChecked(undefined)}>
+          <VuiButtonSecondary color="neutral" size="s" onClick={() => setMaybeChecked(undefined)}>
             Reset
           </VuiButtonSecondary>
         </VuiFlexItem>

--- a/src/lib/components/toggle/Toggle.tsx
+++ b/src/lib/components/toggle/Toggle.tsx
@@ -5,6 +5,9 @@ import { VuiText } from "../typography/Text";
 
 type Props = {
   id?: string;
+  // When `undefined`, the toggle renders in an indeterminate "unset" state. Native checkboxes
+  // never emit indeterminate from `onChange` — callers that want to return to the unset state
+  // must reset their stored value to `undefined` themselves.
   checked?: boolean;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   label?: string;
@@ -12,7 +15,6 @@ type Props = {
 
 export const VuiToggle = ({ id, checked, onChange, label, ...rest }: Props) => {
   let labelId;
-
   const inputProps: Record<string, string> = {};
 
   if (label) {
@@ -25,9 +27,12 @@ export const VuiToggle = ({ id, checked, onChange, label, ...rest }: Props) => {
       <VuiFlexItem grow={false}>
         <label className="vuiToggle" {...rest}>
           <input
+            ref={(el) => {
+              if (el) el.indeterminate = checked === undefined;
+            }}
             className="vuiToggle__input"
             type="checkbox"
-            checked={checked}
+            checked={checked ?? false}
             onChange={onChange}
             id={id}
             {...inputProps}

--- a/src/lib/components/toggle/_index.scss
+++ b/src/lib/components/toggle/_index.scss
@@ -28,6 +28,15 @@ $buttonWidth: $toggleWidth * 0.75 - ($buttonOffset * 2);
   &:checked + .vuiToggle__button:before {
     transform: translateX($toggleWidth - $buttonWidth - ($buttonOffset * 2));
   }
+
+  // Indeterminate ("unset") state: knob centered, lighter background to read as inactive.
+  &:indeterminate + .vuiToggle__button {
+    background-color: var(--vui-color-light-shade);
+  }
+
+  &:indeterminate + .vuiToggle__button:before {
+    transform: translateX(($toggleWidth - $buttonWidth - ($buttonOffset * 2)) * 0.5);
+  }
 }
 
 .vuiToggle__button {


### PR DESCRIPTION
## Summary
- Render `VuiToggle` in an indeterminate "unset" state when \`checked\` is \`undefined\` (knob centered, lighter background) instead of silently collapsing to off.
- Driven by the native \`:indeterminate\` pseudo-class on the underlying \`<input type=checkbox>\` (set via a ref callback) — no new prop needed, just leverages the existing nullable \`checked\`.
- Used by p6's LLM creation form to represent capabilities that can be explicitly set OR left blank for the backend to infer from the model name.

## Notes for callers
Native checkboxes never emit indeterminate from \`onChange\`, so a consumer that wants to return to the unset state has to reset its stored value to \`undefined\` itself (e.g. via a \"Reset to default\" button).

## Test plan
- [ ] Visit the Toggle docs page; the second toggle starts in the centered \"unset\" position. Click it — knob slides to on (or off). Click the Reset button — knob returns to centered.
- [ ] Existing call sites that pass an explicit \`boolean\` to \`checked\` are visually unchanged.