### PR TITLE
Add colors for table bulk actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "16.8.0",
+  "version": "17.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "16.8.0",
+      "version": "17.1.0",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "17.0.1",
+  "version": "17.1.0",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",

--- a/src/docs/pages/table/Table.tsx
+++ b/src/docs/pages/table/Table.tsx
@@ -228,16 +228,17 @@ export const Table = () => {
       testId: "editAction"
     },
     {
+      label: "Search",
+      href: (person: Person) => `https://www.google.com/search?q=${person.name}`,
+      testId: "searchAction"
+    },
+    {
       label: "Delete",
       onClick: (person: Person) => {
         console.log("Delete", person);
       },
-      testId: "deleteAction"
-    },
-    {
-      label: "Search",
-      href: (person: Person) => `https://www.google.com/search?q=${person.name}`,
-      testId: "searchAction"
+      testId: "deleteAction",
+      color: "danger" as const
     }
   ];
 
@@ -293,7 +294,8 @@ export const Table = () => {
             label: "Delete",
             onClick: (people: Person[]) => {
               console.log("Delete", people);
-            }
+            },
+            color: "danger" as const
           }
         ]
       }

--- a/src/lib/components/table/TableBulkActions.tsx
+++ b/src/lib/components/table/TableBulkActions.tsx
@@ -20,12 +20,12 @@ export const VuiTableBulkActions = <T extends Row>({ selectedRows, actions }: Pr
   if (actions.length === 1) {
     content = (
       <VuiButtonSecondary
-        color="neutral"
+        color={actions[0].color ?? "neutral"}
         size="m"
         data-testid={actions[0].testId}
         onClick={() => actions[0].onClick && actions[0].onClick(selectedRows)}
       >
-        {actions[0].label}
+        {`${actions[0].label} (${selectedRows.length})`}
       </VuiButtonSecondary>
     );
   } else {
@@ -35,7 +35,7 @@ export const VuiTableBulkActions = <T extends Row>({ selectedRows, actions }: Pr
         setIsOpen={() => setIsOpen(!isOpen)}
         button={
           <VuiButtonSecondary
-            color="neutral"
+            color="primary"
             size="m"
             data-testid="bulkActionsMenuButton"
             icon={

--- a/src/lib/components/table/TableRowActions.tsx
+++ b/src/lib/components/table/TableRowActions.tsx
@@ -4,6 +4,7 @@ import { VuiOptionsList } from "../optionsList/OptionsList";
 import { VuiPopover } from "../popover/Popover";
 import { VuiIcon } from "../icon/Icon";
 import { VuiButtonSecondary } from "../button/ButtonSecondary";
+import { ButtonColor } from "../button/types";
 import { Row } from "./types";
 
 export type Action<T> = {
@@ -12,6 +13,7 @@ export type Action<T> = {
   onClick?: (row: T) => void;
   href?: (row: T) => string | undefined;
   testId?: string;
+  color?: ButtonColor;
 };
 
 export type Props<T> = {
@@ -26,9 +28,9 @@ export const VuiTableRowActions = <T extends Row>({ row, actions, onToggle, test
 
   // Filter out disabled actions.
   const actionOptions = actions.reduce((acc, action) => {
-    const { label, isDisabled, onClick, href, testId } = action;
+    const { label, isDisabled, onClick, href, testId, color } = action;
     if (!isDisabled?.(row)) {
-      acc.push({ label, onClick, href: href?.(row), value: row, testId });
+      acc.push({ label, onClick, href: href?.(row), value: row, testId, color });
     }
     return acc;
   }, [] as any);


### PR DESCRIPTION
# feat: Add colors for table bulk actions

## Summary 

Enhances the `VuiTable`'s api to accept `color` prop for the actions. This includes both the row actions and bulk actions. The default is the current `neutral` color. 

### Other changes:

- Also renders the multi-action bulk popover trigger as color="primary" so a row selection is hard to miss. This was previously `neutral`.
- Shows number of selected rows with label for a single bulk action button. ("{label} ({N})")

## Screenshots

#### single bulk action `neutral` with number of selected rows

<img width="1182" height="254" alt="Screenshot 2026-05-14 at 2 53 14 PM" src="https://github.com/user-attachments/assets/b0801282-186d-49cb-8f96-d3807c02fb95" />

#### single bulk action `danger` with number of selected rows 

<img width="1187" height="267" alt="Screenshot 2026-05-14 at 2 52 36 PM" src="https://github.com/user-attachments/assets/4eeaaee2-43bb-415b-92b3-a25cb8022ea2" />

#### multi-bulk action `primary`

<img width="1181" height="224" alt="Screenshot 2026-05-14 at 2 48 02 PM" src="https://github.com/user-attachments/assets/fbe4bad5-825b-4c58-b94c-8ddbdf479bae" />

#### multi-bulk action options in custom colors

<img width="1189" height="241" alt="Screenshot 2026-05-14 at 2 47 53 PM" src="https://github.com/user-attachments/assets/cac05994-33c1-48fe-a23d-029cc013213d" />

#### optional color enhancement for row actions

<img width="280" height="177" alt="Screenshot 2026-05-14 at 2 50 11 PM" src="https://github.com/user-attachments/assets/28be8a98-92d2-4017-8500-7cc821ae68ea" />

