### PR TITLE
Extend icon support in table actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "17.1.0",
+  "version": "17.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "17.1.0",
+      "version": "17.2.0",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "17.1.0",
+  "version": "17.2.0",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",

--- a/src/docs/pages/table/Table.tsx
+++ b/src/docs/pages/table/Table.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../../lib";
 import { VuiTable } from "../../../lib/components/table/Table";
 import { createFakePeople, Person } from "./createFakePeople";
-import { BiError } from "react-icons/bi";
+import { BiError, BiTrash } from "react-icons/bi";
 
 const ROWS_PER_PAGE = 20;
 const people: Person[] = createFakePeople(152);
@@ -238,7 +238,12 @@ export const Table = () => {
         console.log("Delete", person);
       },
       testId: "deleteAction",
-      color: "danger" as const
+      color: "danger" as const,
+      icon: (
+        <VuiIcon color="danger">
+          <BiTrash />
+        </VuiIcon>
+      )
     }
   ];
 
@@ -295,7 +300,12 @@ export const Table = () => {
             onClick: (people: Person[]) => {
               console.log("Delete", people);
             },
-            color: "danger" as const
+            color: "danger" as const,
+            icon: (
+              <VuiIcon color="danger">
+                <BiTrash />
+              </VuiIcon>
+            )
           }
         ]
       }

--- a/src/lib/components/table/TableBulkActions.tsx
+++ b/src/lib/components/table/TableBulkActions.tsx
@@ -24,6 +24,7 @@ export const VuiTableBulkActions = <T extends Row>({ selectedRows, actions }: Pr
         size="m"
         data-testid={actions[0].testId}
         onClick={() => actions[0].onClick && actions[0].onClick(selectedRows)}
+        icon={actions[0].icon}
       >
         {`${actions[0].label} (${selectedRows.length})`}
       </VuiButtonSecondary>

--- a/src/lib/components/table/TableRowActions.tsx
+++ b/src/lib/components/table/TableRowActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ReactElement, useState } from "react";
 import { BiCaretDown } from "react-icons/bi";
 import { VuiOptionsList } from "../optionsList/OptionsList";
 import { VuiPopover } from "../popover/Popover";
@@ -14,6 +14,7 @@ export type Action<T> = {
   href?: (row: T) => string | undefined;
   testId?: string;
   color?: ButtonColor;
+  icon?: ReactElement | null;
 };
 
 export type Props<T> = {
@@ -28,9 +29,9 @@ export const VuiTableRowActions = <T extends Row>({ row, actions, onToggle, test
 
   // Filter out disabled actions.
   const actionOptions = actions.reduce((acc, action) => {
-    const { label, isDisabled, onClick, href, testId, color } = action;
+    const { label, isDisabled, onClick, href, testId, color, icon } = action;
     if (!isDisabled?.(row)) {
-      acc.push({ label, onClick, href: href?.(row), value: row, testId, color });
+      acc.push({ label, onClick, href: href?.(row), value: row, testId, color, icon });
     }
     return acc;
   }, [] as any);


### PR DESCRIPTION
# feat: Extend icon support in table actions

## Summary

Allows passing icons to the table `actions` and `selection.bulkActions`

<img width="1192" height="387" alt="image" src="https://github.com/user-attachments/assets/a96604c9-c639-4c4a-a0b7-5a7ddf293966" />
