### PR TITLE
Prevent overlay components from blocking content beneath from being clicked while it's closing

### DIFF
--- a/src/lib/components/drawer/Drawer.tsx
+++ b/src/lib/components/drawer/Drawer.tsx
@@ -90,6 +90,9 @@ export const VuiDrawer = ({
       {(isOpen || isContentVisible || showTransition) && (
         <VuiScreenBlock isHidden={!isOpen}>
           <FocusOn
+            // Disable the focus guard as soon as the drawer begins closing
+            // so it doesn't intercept clicks while transitioning out.
+            enabled={isOpen}
             onEscapeKey={onCloseDelayed}
             onClickOutside={handleClickOutside}
             // Enable manual focus return to work.

--- a/src/lib/components/drawer/_index.scss
+++ b/src/lib/components/drawer/_index.scss
@@ -16,6 +16,7 @@ $drawerWidth: 680px;
   z-index: $drawerZIndex;
   right: -$drawerWidth;
   transition: right $transitionSpeed cubic-bezier(0, 1, 0, 1);
+  pointer-events: none;
 
   @media screen and (max-width: ($drawerWidth + $sizeM)) {
     max-width: calc(100% - $sizeM);
@@ -24,6 +25,7 @@ $drawerWidth: 680px;
 
 .vuiDrawer-isLoaded {
   right: 0;
+  pointer-events: auto;
 }
 
 .vuiDrawerHeader {

--- a/src/lib/components/modal/Modal.tsx
+++ b/src/lib/components/modal/Modal.tsx
@@ -96,6 +96,9 @@ export const VuiModal = ({
       {(isOpen || isContentVisible || showTransition) && (
         <VuiScreenBlock key={key} type="modal" isHidden={!isOpen}>
           <FocusOn
+            // Disable the focus guard as soon as the modal begins closing
+            // so it doesn't intercept clicks while transitioning out.
+            enabled={isOpen}
             onEscapeKey={onCloseDelayed}
             onClickOutside={canClickOutsideToClose ? handleClickOutside : undefined}
             // Enable manual focus return to work.

--- a/src/lib/components/modal/_index.scss
+++ b/src/lib/components/modal/_index.scss
@@ -28,9 +28,13 @@
   background-color: var(--vui-color-empty-shade);
   border-radius: $sizeXxs;
   z-index: $modalZIndex;
-  pointer-events: all;
+  pointer-events: none;
   box-shadow: rgba(57, 57, 75, 0.25) 0px 13px 27px -5px, rgba(0, 0, 0, 0.3) 0px 8px 16px -8px;
   transition: height $transitionSpeed, max-width $transitionSpeed, max-height $transitionSpeed;
+}
+
+.vuiModalContainer-isLoaded .vuiModal {
+  pointer-events: all;
 }
 
 $size: (

--- a/src/lib/components/popover/Popover.tsx
+++ b/src/lib/components/popover/Popover.tsx
@@ -226,6 +226,9 @@ export const VuiPopover = ({
       <VuiPortal>
         {(isOpen || isContentVisible || showTransition) && position && (
           <FocusOn
+            // Disable the focus guard as soon as the popover begins closing
+            // so it doesn't intercept clicks while transitioning out.
+            enabled={isOpen}
             onEscapeKey={onCloseDelayed}
             onClickOutside={onCloseDelayed}
             // Enable manual focus return to work.

--- a/src/lib/components/popover/_index.scss
+++ b/src/lib/components/popover/_index.scss
@@ -9,11 +9,13 @@
   opacity: 0;
   transform: translateY(-$sizeXs);
   transition: opacity $transitionSpeed, transform $transitionSpeed;
+  pointer-events: none;
 }
 
 .vuiPopover-isLoaded {
   opacity: 1;
   transform: translateY(0);
+  pointer-events: auto;
 }
 
 .vuiPopover--allowOverflow {


### PR DESCRIPTION
This eliminates one potential source of flakiness in e2e tests.

Applies to:
* Popover
* Modal
* Drawer