### PR TITLE
Simplify padding on VuiSimpleCard. Add example of sophisticated card layout.

### DIFF
--- a/src/docs/pages/card/SimpleCard.tsx
+++ b/src/docs/pages/card/SimpleCard.tsx
@@ -1,8 +1,11 @@
 import { useState } from "react";
 import {
+  VuiBadge,
   VuiFlexContainer,
   VuiGrid,
+  VuiHorizontalRule,
   VuiIcon,
+  VuiPatch,
   VuiSelect,
   VuiSimpleCard,
   VuiSpacer,
@@ -10,18 +13,16 @@ import {
   VuiTextColor,
   VuiTitle
 } from "../../../lib";
-import { BiPencil } from "react-icons/bi";
+import { BiData, BiPencil, BiRightArrowAlt } from "react-icons/bi";
 
 const paddingOptions = [
-  { text: "Extra extra small", value: "xxs" },
-  { text: "Extra small", value: "xs" },
   { text: "Small", value: "s" },
   { text: "Medium", value: "m" },
   { text: "Large", value: "l" }
 ];
 
 export const SimpleCard = () => {
-  const [padding, setPadding] = useState<"xxs" | "xs" | "s" | "m" | "l">("xs");
+  const [padding, setPadding] = useState<"s" | "m" | "l">("l");
 
   return (
     <>
@@ -29,7 +30,7 @@ export const SimpleCard = () => {
         id="paddingOptions"
         options={paddingOptions}
         value={padding}
-        onChange={(event) => setPadding(event.target.value as "xxs" | "xs" | "s" | "m" | "l")}
+        onChange={(event) => setPadding(event.target.value as "s" | "m" | "l")}
       />
 
       <VuiSpacer size="m" />
@@ -130,7 +131,11 @@ export const SimpleCard = () => {
           </VuiText>
         </VuiSimpleCard>
 
-        <VuiSimpleCard padding={padding} warning="Missing configuration" onClick={() => console.log("Raccoon says hi!")}>
+        <VuiSimpleCard
+          padding={padding}
+          warning="Missing configuration"
+          onClick={() => console.log("Raccoon says hi!")}
+        >
           <VuiTitle size="xs">
             <h3>Raccoon</h3>
           </VuiTitle>
@@ -144,6 +149,67 @@ export const SimpleCard = () => {
           </VuiText>
         </VuiSimpleCard>
       </VuiGrid>
+
+      <VuiSpacer size="m" />
+
+      <div style={{ maxWidth: "400px" }}>
+        <VuiSimpleCard padding={padding} onClick={() => console.log("Selected")}>
+          <VuiFlexContainer alignItems="start" justifyContent="spaceBetween">
+            <VuiPatch color="emerald" size="s">
+              <VuiIcon>
+                <BiData />
+              </VuiIcon>
+            </VuiPatch>
+
+            <VuiBadge color="primary">Sources</VuiBadge>
+          </VuiFlexContainer>
+
+          <VuiSpacer size="m" />
+
+          <VuiTitle size="s">
+            <h3>
+              <strong>Tyrannodata</strong>
+            </h3>
+          </VuiTitle>
+
+          <VuiSpacer size="xxs" />
+
+          <VuiText size="xs">
+            <p>
+              <VuiTextColor color="subdued">Terrible, horrible, no-good data</VuiTextColor>
+            </p>
+          </VuiText>
+
+          <VuiSpacer size="s" />
+
+          <VuiText size="s">
+            <p>
+              <VuiTextColor color="subdued">
+                This data has seen better days. Where once it soared, mighty and free, above the lesser data, these days
+                it spends its time scavenging for bytes.
+              </VuiTextColor>
+            </p>
+          </VuiText>
+
+          <VuiSpacer size="l" />
+
+          <VuiHorizontalRule color="subdued" />
+
+          <VuiSpacer size="l" />
+
+          <VuiFlexContainer alignItems="center" justifyContent="spaceBetween">
+            <VuiText size="s">
+              <p>
+                <VuiTextColor color="primary">Select</VuiTextColor>
+              </p>
+            </VuiText>
+
+            <VuiIcon color="primary" size="s">
+              <BiRightArrowAlt />
+            </VuiIcon>
+          </VuiFlexContainer>
+        </VuiSimpleCard>
+      </div>
     </>
   );
 };

--- a/src/lib/components/card/SimpleCard.tsx
+++ b/src/lib/components/card/SimpleCard.tsx
@@ -9,13 +9,23 @@ type Props = {
   fullHeight?: boolean;
   href?: string;
   onClick?: (e: MouseEvent) => void;
-  padding?: "xxs" | "xs" | "s" | "m" | "l";
+  padding?: "s" | "m" | "l";
   children?: React.ReactNode;
   error?: string | ReactNode;
   warning?: string | ReactNode;
 };
 
-export const VuiSimpleCard = ({ href, className, fullHeight, padding = "s", children, onClick, error, warning, ...rest }: Props) => {
+export const VuiSimpleCard = ({
+  href,
+  className,
+  fullHeight,
+  padding = "s",
+  children,
+  onClick,
+  error,
+  warning,
+  ...rest
+}: Props) => {
   const { createLink } = useVuiContext();
 
   const classes = classNames(

--- a/src/lib/components/card/_index.scss
+++ b/src/lib/components/card/_index.scss
@@ -179,28 +179,11 @@
 }
 
 .vuiSimpleCard--interactive {
-  border: 1px solid var(--vui-color-primary-highlight-shade);
   transition: box-shadow $transitionSpeed, border-color $transitionSpeed;
 
   &:hover {
-    border-color: var(--vui-color-primary-shade);
-    box-shadow: $shadowLargeEnd;
-  }
-}
-
-.vuiSimpleCard--danger {
-  border-color: var(--vui-color-danger-shade);
-
-  &.vuiSimpleCard--interactive:hover {
-    border-color: var(--vui-color-danger-shade);
-  }
-}
-
-.vuiSimpleCard--warning {
-  border-color: var(--vui-color-warning-shade);
-
-  &.vuiSimpleCard--interactive:hover {
-    border-color: var(--vui-color-warning-shade);
+    border-color: var(--vui-color-primary-highlight-shade);
+    box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px;
   }
 }
 
@@ -208,22 +191,14 @@
   height: 100%;
 }
 
-.vuiSimpleCard--xxs {
-  padding: $sizeXs $sizeS;
-}
-
-.vuiSimpleCard--xs {
-  padding: $sizeS $sizeM;
-}
-
 .vuiSimpleCard--s {
-  padding: $sizeM $sizeL;
+  padding: $sizeS;
 }
 
 .vuiSimpleCard--m {
-  padding: $sizeL $sizeXl;
+  padding: $sizeM;
 }
 
 .vuiSimpleCard--l {
-  padding: $sizeXl $sizeXxl;
+  padding: $sizeL;
 }


### PR DESCRIPTION
Breaking change. Removes some padding values from VuiSimpleCard.

<img width="414" height="311" alt="image" src="https://github.com/user-attachments/assets/27eab064-4efe-4e8f-a3c6-24e8a08c0479" />
