### PR TITLE
Surface VUI version in docs header

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "start": "PORT=2000 react-scripts start",
-    "buildDocs": "BUILD_PATH='./docs/public' PUBLIC_URL='.' react-scripts build",
+    "start": "REACT_APP_VUI_VERSION=$npm_package_version PORT=2000 react-scripts start",
+    "buildDocs": "REACT_APP_VUI_VERSION=$npm_package_version BUILD_PATH='./docs/public' PUBLIC_URL='.' react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "build": "npx tsc --project tsconfig.lib.json && npm run copyStyleUtils && npm run copyComponentStyles && npm run compileCss",

--- a/src/docs/Docs.tsx
+++ b/src/docs/Docs.tsx
@@ -17,8 +17,10 @@ import { HeaderLogo } from "./components/HeaderLogo";
 import { categories } from "./pages";
 import { Home } from "./Home";
 import { Page } from "./Page";
-import packageJson from "../../package.json";
 import "./index.scss";
+
+// Baked in at build time from package.json via the REACT_APP_VUI_VERSION env var.
+const VUI_VERSION = process.env.REACT_APP_VUI_VERSION;
 
 export const Docs = () => {
   return (
@@ -69,9 +71,11 @@ const DocsContent = () => {
               </VuiTitle>
             </VuiFlexItem>
 
-            <VuiFlexItem grow={false} shrink={false}>
-              <VuiBadge color="neutral">{`v${packageJson.version}`}</VuiBadge>
-            </VuiFlexItem>
+            {VUI_VERSION && (
+              <VuiFlexItem grow={false} shrink={false}>
+                <VuiBadge color="neutral">{`v${VUI_VERSION}`}</VuiBadge>
+              </VuiFlexItem>
+            )}
 
             <VuiFlexItem grow={false} shrink={false}>
               <VuiButtonSecondary size="s" color="neutral" href="/">

--- a/src/docs/Docs.tsx
+++ b/src/docs/Docs.tsx
@@ -10,12 +10,14 @@ import {
   VuiAppLayout,
   VuiButtonSecondary,
   VuiContextProvider,
+  VuiBadge,
   LinkProps
 } from "../lib";
 import { HeaderLogo } from "./components/HeaderLogo";
 import { categories } from "./pages";
 import { Home } from "./Home";
 import { Page } from "./Page";
+import { version } from "../../package.json";
 import "./index.scss";
 
 export const Docs = () => {
@@ -65,6 +67,10 @@ const DocsContent = () => {
               <VuiTitle size="xs">
                 <h1>Vectara UI Library</h1>
               </VuiTitle>
+            </VuiFlexItem>
+
+            <VuiFlexItem grow={false} shrink={false}>
+              <VuiBadge color="neutral">{`v${version}`}</VuiBadge>
             </VuiFlexItem>
 
             <VuiFlexItem grow={false} shrink={false}>

--- a/src/docs/Docs.tsx
+++ b/src/docs/Docs.tsx
@@ -17,7 +17,7 @@ import { HeaderLogo } from "./components/HeaderLogo";
 import { categories } from "./pages";
 import { Home } from "./Home";
 import { Page } from "./Page";
-import { version } from "../../package.json";
+import packageJson from "../../package.json";
 import "./index.scss";
 
 export const Docs = () => {
@@ -70,7 +70,7 @@ const DocsContent = () => {
             </VuiFlexItem>
 
             <VuiFlexItem grow={false} shrink={false}>
-              <VuiBadge color="neutral">{`v${version}`}</VuiBadge>
+              <VuiBadge color="neutral">{`v${packageJson.version}`}</VuiBadge>
             </VuiFlexItem>
 
             <VuiFlexItem grow={false} shrink={false}>


### PR DESCRIPTION
## Summary
- Display the current library version (from `package.json`) as a neutral `VuiBadge` next to the **Vectara UI Library** title in the docs app header.

## Test plan
- [ ] Run the docs app (`npm start`) and confirm `v19.0.0` appears next to the title in the header.
- [ ] Verify the badge updates automatically on future version bumps (sourced from `package.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)