### PR TITLE
Add cross-chart hover sync and value formatting props

### DIFF
--- a/src/docs/pages/composedChart/FormattedAxes.tsx
+++ b/src/docs/pages/composedChart/FormattedAxes.tsx
@@ -1,0 +1,32 @@
+import { VuiComposedChart } from "../../../lib";
+
+// Request volume (bars, left axis) against p95 latency (line, right axis). The
+// two axes measure different units, so each gets its own value formatter — and
+// the shared tooltip formats each row by the axis its series belongs to.
+const data = [
+  { time: "10:00", requests: 4200, latency: 820 },
+  { time: "10:05", requests: 5100, latency: 1240 },
+  { time: "10:10", requests: 6800, latency: 980 },
+  { time: "10:15", requests: 7400, latency: 2100 },
+  { time: "10:20", requests: 8200, latency: 1560 },
+  { time: "10:25", requests: 9100, latency: 1180 }
+];
+
+const formatCount = (value: number) => (value >= 1000 ? `${(value / 1000).toFixed(1)}k` : `${value}`);
+
+const formatMs = (ms: number) => (ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`);
+
+export const FormattedAxes = () => {
+  return (
+    <VuiComposedChart
+      data={data}
+      categoryKey="time"
+      formatLeftValue={formatCount}
+      formatRightValue={formatMs}
+      series={[
+        { dataKey: "requests", name: "Requests", type: "bar", axis: "left" },
+        { dataKey: "latency", name: "p95 latency", type: "line", axis: "right", curved: true }
+      ]}
+    />
+  );
+};

--- a/src/docs/pages/composedChart/index.tsx
+++ b/src/docs/pages/composedChart/index.tsx
@@ -1,6 +1,8 @@
 import { Basic } from "./Basic";
+import { FormattedAxes } from "./FormattedAxes";
 
 const BasicSource = require("!!raw-loader!./Basic");
+const FormattedAxesSource = require("!!raw-loader!./FormattedAxes");
 
 export const composedChart = {
   name: "Composed chart",
@@ -10,6 +12,11 @@ export const composedChart = {
       name: "Basic",
       component: <Basic />,
       source: BasicSource.default.toString()
+    },
+    {
+      name: "Formatted axes",
+      component: <FormattedAxes />,
+      source: FormattedAxesSource.default.toString()
     }
   ]
 };

--- a/src/docs/pages/lineChart/FormattedValues.tsx
+++ b/src/docs/pages/lineChart/FormattedValues.tsx
@@ -1,0 +1,25 @@
+import { VuiLineChart } from "../../../lib";
+
+const data = [
+  { time: "10:00", latency: 820 },
+  { time: "10:05", latency: 1240 },
+  { time: "10:10", latency: 980 },
+  { time: "10:15", latency: 2100 },
+  { time: "10:20", latency: 1560 },
+  { time: "10:25", latency: 1180 }
+];
+
+// formatValue formats both the value-axis ticks and the tooltip readout, so raw
+// millisecond values render as human-readable durations.
+const formatMs = (ms: number) => (ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`);
+
+export const FormattedValues = () => {
+  return (
+    <VuiLineChart
+      data={data}
+      categoryKey="time"
+      formatValue={formatMs}
+      series={[{ dataKey: "latency", name: "Latency" }]}
+    />
+  );
+};

--- a/src/docs/pages/lineChart/Synced.tsx
+++ b/src/docs/pages/lineChart/Synced.tsx
@@ -1,0 +1,48 @@
+import { VuiBarChart, VuiLineChart, VuiSpacer } from "../../../lib";
+
+// The two charts cover the same timeline at different resolutions. Hovering
+// either one highlights the matching timestamp on both. syncMethod "value"
+// aligns by the x-axis value rather than by data index, which is what lets
+// charts with differing point counts stay in step.
+const latency = [
+  { time: "10:00", p95: 320 },
+  { time: "10:10", p95: 280 },
+  { time: "10:20", p95: 460 },
+  { time: "10:30", p95: 240 }
+];
+
+const requests = [
+  { time: "10:00", requests: 1200 },
+  { time: "10:05", requests: 1800 },
+  { time: "10:10", requests: 1500 },
+  { time: "10:15", requests: 2100 },
+  { time: "10:20", requests: 1900 },
+  { time: "10:25", requests: 1700 },
+  { time: "10:30", requests: 1400 }
+];
+
+const SYNC_ID = "trafficDemo";
+
+export const Synced = () => {
+  return (
+    <>
+      <VuiLineChart
+        data={latency}
+        categoryKey="time"
+        syncId={SYNC_ID}
+        syncMethod="value"
+        height={200}
+        series={[{ dataKey: "p95", name: "p95 latency (ms)" }]}
+      />
+      <VuiSpacer size="m" />
+      <VuiBarChart
+        data={requests}
+        categoryKey="time"
+        syncId={SYNC_ID}
+        syncMethod="value"
+        height={200}
+        series={[{ dataKey: "requests", name: "Requests" }]}
+      />
+    </>
+  );
+};

--- a/src/docs/pages/lineChart/index.tsx
+++ b/src/docs/pages/lineChart/index.tsx
@@ -2,11 +2,15 @@ import { Basic } from "./Basic";
 import { Curved } from "./Curved";
 import { Area } from "./Area";
 import { StackedArea } from "./StackedArea";
+import { FormattedValues } from "./FormattedValues";
+import { Synced } from "./Synced";
 
 const BasicSource = require("!!raw-loader!./Basic");
 const CurvedSource = require("!!raw-loader!./Curved");
 const AreaSource = require("!!raw-loader!./Area");
 const StackedAreaSource = require("!!raw-loader!./StackedArea");
+const FormattedValuesSource = require("!!raw-loader!./FormattedValues");
+const SyncedSource = require("!!raw-loader!./Synced");
 
 export const lineChart = {
   name: "Line chart",
@@ -31,6 +35,16 @@ export const lineChart = {
       name: "Stacked area",
       component: <StackedArea />,
       source: StackedAreaSource.default.toString()
+    },
+    {
+      name: "Formatted values",
+      component: <FormattedValues />,
+      source: FormattedValuesSource.default.toString()
+    },
+    {
+      name: "Synced",
+      component: <Synced />,
+      source: SyncedSource.default.toString()
     }
   ]
 };

--- a/src/lib/components/chart/BarChart.tsx
+++ b/src/lib/components/chart/BarChart.tsx
@@ -35,6 +35,14 @@ type Props = {
   showLegend?: boolean;
   showGrid?: boolean;
   showTooltip?: boolean;
+  // Charts sharing a syncId highlight the same category when the user hovers any
+  // one of them. Omit to leave a chart unsynced.
+  syncId?: string;
+  // Align the shared cursor by axis "value" rather than by data "index". Use
+  // "value" when synced charts have differing point counts. Defaults to "index".
+  syncMethod?: "index" | "value";
+  // Formats value-axis tick labels and tooltip values, e.g. milliseconds to "1.2s".
+  formatValue?: (value: number) => string;
   "data-testid"?: string;
 };
 
@@ -48,6 +56,9 @@ export const VuiBarChart = ({
   showLegend = series.length > 1,
   showGrid = true,
   showTooltip = true,
+  syncId,
+  syncMethod,
+  formatValue,
   ...rest
 }: Props) => {
   const isHorizontal = orientation === "bars";
@@ -61,21 +72,27 @@ export const VuiBarChart = ({
     </>
   );
   const valueAxis = isHorizontal ? (
-    <XAxis type="number" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
+    <XAxis type="number" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} tickFormatter={formatValue} />
   ) : (
-    <YAxis type="number" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
+    <YAxis type="number" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} tickFormatter={formatValue} />
   );
 
   return (
     <div className="vuiBarChart" {...rest}>
       <ResponsiveContainer width="100%" height={height}>
-        <RechartsBarChart data={data} layout={isHorizontal ? "vertical" : "horizontal"}>
+        <RechartsBarChart data={data} layout={isHorizontal ? "vertical" : "horizontal"} syncId={syncId} syncMethod={syncMethod}>
           {showGrid && (
             <CartesianGrid stroke="var(--vui-color-border-light)" vertical={isHorizontal} horizontal={!isHorizontal} />
           )}
           {categoryAxis}
           {valueAxis}
-          {showTooltip && <Tooltip cursor={{ fill: "var(--vui-color-light-shade)" }} {...chartTooltipProps} />}
+          {showTooltip && (
+            <Tooltip
+              cursor={{ fill: "var(--vui-color-light-shade)" }}
+              formatter={formatValue && ((value) => (typeof value === "number" ? formatValue(value) : value))}
+              {...chartTooltipProps}
+            />
+          )}
           {showLegend && <Legend {...chartLegendProps} />}
           {series.map((s, index) => (
             <Bar

--- a/src/lib/components/chart/ComposedChart.tsx
+++ b/src/lib/components/chart/ComposedChart.tsx
@@ -39,6 +39,18 @@ type Props = {
   showLegend?: boolean;
   showGrid?: boolean;
   showTooltip?: boolean;
+  // Charts sharing a syncId highlight the same category when the user hovers any
+  // one of them. Omit to leave a chart unsynced.
+  syncId?: string;
+  // Align the shared cursor by axis "value" rather than by data "index". Use
+  // "value" when synced charts have differing point counts. Defaults to "index".
+  syncMethod?: "index" | "value";
+  // Formats tick labels for the left y-axis, e.g. milliseconds to "1.2s". Also
+  // applied to tooltip values for series measured against the left axis.
+  formatLeftValue?: (value: number) => string;
+  // Formats tick labels for the right y-axis (present when a series opts into it).
+  // Also applied to tooltip values for series measured against the right axis.
+  formatRightValue?: (value: number) => string;
   "data-testid"?: string;
 };
 
@@ -50,21 +62,45 @@ export const VuiComposedChart = ({
   showLegend = series.length > 1,
   showGrid = true,
   showTooltip = true,
+  syncId,
+  syncMethod,
+  formatLeftValue,
+  formatRightValue,
   ...rest
 }: Props) => {
   const hasRightAxis = series.some((s) => s.axis === "right");
 
+  // A composed chart can mix two axes, so the tooltip formats each value by the
+  // axis its series is measured against rather than a single shared formatter.
+  const axisByDataKey = new Map(series.map((s) => [s.dataKey, s.axis ?? "left"]));
+  const hasValueFormatter = Boolean(formatLeftValue || formatRightValue);
+
   return (
     <div className="vuiComposedChart" {...rest}>
       <ResponsiveContainer width="100%" height={height}>
-        <RechartsComposedChart data={data}>
+        <RechartsComposedChart data={data} syncId={syncId} syncMethod={syncMethod}>
           {showGrid && <CartesianGrid stroke="var(--vui-color-border-light)" vertical={false} />}
           <XAxis dataKey={categoryKey} tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
-          <YAxis yAxisId="left" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
+          <YAxis yAxisId="left" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} tickFormatter={formatLeftValue} />
           {hasRightAxis && (
-            <YAxis yAxisId="right" orientation="right" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
+            <YAxis yAxisId="right" orientation="right" tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} tickFormatter={formatRightValue} />
           )}
-          {showTooltip && <Tooltip cursor={{ fill: "var(--vui-color-light-shade)" }} {...chartTooltipProps} />}
+          {showTooltip && (
+            <Tooltip
+              cursor={{ fill: "var(--vui-color-light-shade)" }}
+              formatter={
+                hasValueFormatter
+                  ? (value, _name, item) => {
+                      if (typeof value !== "number") return value;
+                      const format =
+                        axisByDataKey.get(String(item?.dataKey)) === "right" ? formatRightValue : formatLeftValue;
+                      return format ? format(value) : value;
+                    }
+                  : undefined
+              }
+              {...chartTooltipProps}
+            />
+          )}
           {showLegend && <Legend {...chartLegendProps} />}
           {series.map((s, index) => {
             const color = s.color ? getChartColor(s.color) : getChartColorByIndex(index);

--- a/src/lib/components/chart/LineChart.tsx
+++ b/src/lib/components/chart/LineChart.tsx
@@ -42,6 +42,14 @@ type Props = {
   showLegend?: boolean;
   showGrid?: boolean;
   showTooltip?: boolean;
+  // Charts sharing a syncId highlight the same x position when the user hovers
+  // any one of them. Omit to leave a chart unsynced.
+  syncId?: string;
+  // Align the shared cursor by x-axis "value" rather than by data "index". Use
+  // "value" when synced charts have differing point counts. Defaults to "index".
+  syncMethod?: "index" | "value";
+  // Formats value-axis tick labels and tooltip values, e.g. milliseconds to "1.2s".
+  formatValue?: (value: number) => string;
   "data-testid"?: string;
 };
 
@@ -56,6 +64,9 @@ export const VuiLineChart = ({
   showLegend = series.length > 1,
   showGrid = true,
   showTooltip = true,
+  syncId,
+  syncMethod,
+  formatValue,
   ...rest
 }: Props) => {
   const isArea = variant === "area" || variant === "stacked-area";
@@ -65,8 +76,14 @@ export const VuiLineChart = ({
     <>
       {showGrid && <CartesianGrid stroke="var(--vui-color-border-light)" vertical={false} />}
       <XAxis dataKey={categoryKey} tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
-      <YAxis tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} />
-      {showTooltip && <Tooltip cursor={{ stroke: "var(--vui-color-border-medium)" }} {...chartTooltipProps} />}
+      <YAxis tick={chartTickStyle} axisLine={chartAxisLineStyle} tickLine={false} tickFormatter={formatValue} />
+      {showTooltip && (
+        <Tooltip
+          cursor={{ stroke: "var(--vui-color-border-medium)" }}
+          formatter={formatValue && ((value) => (typeof value === "number" ? formatValue(value) : value))}
+          {...chartTooltipProps}
+        />
+      )}
       {showLegend && <Legend {...chartLegendProps} />}
     </>
   );
@@ -90,7 +107,7 @@ export const VuiLineChart = ({
     <div className="vuiLineChart" {...rest}>
       <ResponsiveContainer width="100%" height={height}>
         {isArea ? (
-          <RechartsAreaChart data={data}>
+          <RechartsAreaChart data={data} syncId={syncId} syncMethod={syncMethod}>
             {axes}
             {series.map((s, index) => {
               const props = markProps(s, index);
@@ -107,7 +124,7 @@ export const VuiLineChart = ({
             })}
           </RechartsAreaChart>
         ) : (
-          <RechartsLineChart data={data}>
+          <RechartsLineChart data={data} syncId={syncId} syncMethod={syncMethod}>
             {axes}
             {series.map((s, index) => (
               <Line {...markProps(s, index)} />


### PR DESCRIPTION
Add syncId/syncMethod to VuiLineChart, VuiBarChart, and VuiComposedChart so charts sharing a syncId highlight the same x position on hover. Add formatValue to VuiLineChart/VuiBarChart and formatLeftValue/formatRightValue to VuiComposedChart for value-axis tick and tooltip formatting. All props are optional and backward-compatible.

Includes docs examples for synced charts and formatted values/axes.