### PR TITLE
Rationalize background and border colors. Rename light and lighter shades, primary highlight shade.

### DIFF
--- a/src/docs/pages/colorPalette/NeutralColors.tsx
+++ b/src/docs/pages/colorPalette/NeutralColors.tsx
@@ -14,10 +14,7 @@ const neutralSwatches = [
 ];
 
 // Special-purpose accents that sit outside the semantic families.
-const specialSwatches = [
-  { name: "Primary highlight", cssVariable: "--vui-color-primary-highlight-shade", value: "#d9e2ff" },
-  { name: "Subdued", cssVariable: "--vui-color-subdued-shade", value: "#6d7686" }
-];
+const specialSwatches = [{ name: "Subdued", cssVariable: "--vui-color-subdued-shade", value: "#6d7686" }];
 
 export const NeutralColors = () => {
   return (

--- a/src/docs/pages/colorPalette/SemanticColors.tsx
+++ b/src/docs/pages/colorPalette/SemanticColors.tsx
@@ -9,40 +9,40 @@ const families = [
     name: "Accent",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-accent-shade", value: "#5f30c3" },
-      { name: "Light shade", cssVariable: "--vui-color-accent-light-shade", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-accent-lighter-shade", value: "#eee7ff" }
+      { name: "Light shade", cssVariable: "--vui-color-accent-border", value: "50% opacity" },
+      { name: "Lighter shade", cssVariable: "--vui-color-accent-background", value: "#eee7ff" }
     ]
   },
   {
     name: "Primary",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-primary-shade", value: "#045dda" },
-      { name: "Light shade", cssVariable: "--vui-color-primary-light-shade", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-primary-lighter-shade", value: "#f1f7ff" }
+      { name: "Light shade", cssVariable: "--vui-color-primary-border", value: "50% opacity" },
+      { name: "Lighter shade", cssVariable: "--vui-color-primary-background", value: "#f1f7ff" }
     ]
   },
   {
     name: "Success",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-success-shade", value: "#249719" },
-      { name: "Light shade", cssVariable: "--vui-color-success-light-shade", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-success-lighter-shade", value: "#e2f2e0" }
+      { name: "Light shade", cssVariable: "--vui-color-success-border", value: "50% opacity" },
+      { name: "Lighter shade", cssVariable: "--vui-color-success-background", value: "#e2f2e0" }
     ]
   },
   {
     name: "Warning",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-warning-shade", value: "#a86f1b" },
-      { name: "Light shade", cssVariable: "--vui-color-warning-light-shade", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-warning-lighter-shade", value: "#ffeed4" }
+      { name: "Light shade", cssVariable: "--vui-color-warning-border", value: "50% opacity" },
+      { name: "Lighter shade", cssVariable: "--vui-color-warning-background", value: "#ffeed4" }
     ]
   },
   {
     name: "Danger",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-danger-shade", value: "#d22d2d" },
-      { name: "Light shade", cssVariable: "--vui-color-danger-light-shade", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-danger-lighter-shade", value: "#fff1f1" }
+      { name: "Light shade", cssVariable: "--vui-color-danger-border", value: "50% opacity" },
+      { name: "Lighter shade", cssVariable: "--vui-color-danger-background", value: "#fff1f1" }
     ]
   }
 ];

--- a/src/docs/pages/colorPalette/SemanticColors.tsx
+++ b/src/docs/pages/colorPalette/SemanticColors.tsx
@@ -9,40 +9,40 @@ const families = [
     name: "Accent",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-accent-shade", value: "#5f30c3" },
-      { name: "Light shade", cssVariable: "--vui-color-accent-border", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-accent-background", value: "#eee7ff" }
+      { name: "Border", cssVariable: "--vui-color-accent-border", value: "50% opacity" },
+      { name: "Background", cssVariable: "--vui-color-accent-background", value: "#eee7ff" }
     ]
   },
   {
     name: "Primary",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-primary-shade", value: "#045dda" },
-      { name: "Light shade", cssVariable: "--vui-color-primary-border", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-primary-background", value: "#f1f7ff" }
+      { name: "Border", cssVariable: "--vui-color-primary-border", value: "50% opacity" },
+      { name: "Background", cssVariable: "--vui-color-primary-background", value: "#f1f7ff" }
     ]
   },
   {
     name: "Success",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-success-shade", value: "#249719" },
-      { name: "Light shade", cssVariable: "--vui-color-success-border", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-success-background", value: "#e2f2e0" }
+      { name: "Border", cssVariable: "--vui-color-success-border", value: "50% opacity" },
+      { name: "Background", cssVariable: "--vui-color-success-background", value: "#e2f2e0" }
     ]
   },
   {
     name: "Warning",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-warning-shade", value: "#a86f1b" },
-      { name: "Light shade", cssVariable: "--vui-color-warning-border", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-warning-background", value: "#ffeed4" }
+      { name: "Border", cssVariable: "--vui-color-warning-border", value: "50% opacity" },
+      { name: "Background", cssVariable: "--vui-color-warning-background", value: "#ffeed4" }
     ]
   },
   {
     name: "Danger",
     swatches: [
       { name: "Shade", cssVariable: "--vui-color-danger-shade", value: "#d22d2d" },
-      { name: "Light shade", cssVariable: "--vui-color-danger-border", value: "50% opacity" },
-      { name: "Lighter shade", cssVariable: "--vui-color-danger-background", value: "#fff1f1" }
+      { name: "Border", cssVariable: "--vui-color-danger-border", value: "50% opacity" },
+      { name: "Background", cssVariable: "--vui-color-danger-background", value: "#fff1f1" }
     ]
   }
 ];

--- a/src/docs/pages/patch/Sizes.tsx
+++ b/src/docs/pages/patch/Sizes.tsx
@@ -8,7 +8,7 @@ export const Sizes = () => {
     <VuiFlexContainer spacing="m" wrap>
       {sizes.map((size) => (
         <div>
-          <VuiPatch color="indigo" size={size}>
+          <VuiPatch color="primary" size={size}>
             <VuiIcon>
               <BiCompass />
             </VuiIcon>

--- a/src/lib/components/accordion/_index.scss
+++ b/src/lib/components/accordion/_index.scss
@@ -10,7 +10,7 @@
 
   &:hover {
     color: var(--vui-color-primary-shade);
-    background-color: var(--vui-color-primary-lighter-shade);
+    background-color: var(--vui-color-primary-background);
     border-color: rgba(var(--vui-color-primary-shade-rgb), 0.5);
     text-decoration: underline;
   }

--- a/src/lib/components/button/buttonSecondary.scss
+++ b/src/lib/components/button/buttonSecondary.scss
@@ -13,23 +13,23 @@
 // Color
 $color: (
   accent: (
-    "border-color": rgba(var(--vui-color-accent-shade-rgb), 0.5),
+    "border-color": var(--vui-color-accent-border),
     "color": var(--vui-color-accent-shade)
   ),
   primary: (
-    "border-color": rgba(var(--vui-color-primary-shade-rgb), 0.5),
+    "border-color": var(--vui-color-primary-border),
     "color": var(--vui-color-primary-shade)
   ),
   success: (
-    "border-color": rgba(var(--vui-color-success-shade-rgb), 0.5),
+    "border-color": var(--vui-color-success-border),
     "color": var(--vui-color-success-shade)
   ),
   danger: (
-    "border-color": rgba(var(--vui-color-danger-shade-rgb), 0.5),
+    "border-color": var(--vui-color-danger-border),
     "color": var(--vui-color-danger-shade)
   ),
   warning: (
-    "border-color": rgba(var(--vui-color-warning-shade-rgb), 0.5),
+    "border-color": var(--vui-color-warning-border),
     "color": var(--vui-color-warning-shade)
   ),
   neutral: (

--- a/src/lib/components/callout/_index.scss
+++ b/src/lib/components/callout/_index.scss
@@ -23,24 +23,24 @@
 // Color
 $color: (
   accent: (
-    "border-color": var(--vui-color-accent-light-shade),
-    "background-color": var(--vui-color-accent-lighter-shade)
+    "border-color": var(--vui-color-accent-border),
+    "background-color": var(--vui-color-accent-background)
   ),
   primary: (
-    "border-color": var(--vui-color-primary-light-shade),
-    "background-color": var(--vui-color-primary-lighter-shade)
+    "border-color": var(--vui-color-primary-border),
+    "background-color": var(--vui-color-primary-background)
   ),
   success: (
-    "border-color": var(--vui-color-success-light-shade),
-    "background-color": var(--vui-color-success-lighter-shade)
+    "border-color": var(--vui-color-success-border),
+    "background-color": var(--vui-color-success-background)
   ),
   warning: (
-    "border-color": var(--vui-color-warning-light-shade),
-    "background-color": var(--vui-color-warning-lighter-shade)
+    "border-color": var(--vui-color-warning-border),
+    "background-color": var(--vui-color-warning-background)
   ),
   danger: (
-    "border-color": var(--vui-color-danger-light-shade),
-    "background-color": var(--vui-color-danger-lighter-shade)
+    "border-color": var(--vui-color-danger-border),
+    "background-color": var(--vui-color-danger-background)
   ),
   neutral: (
     "border-color": var(--vui-color-medium-shade),

--- a/src/lib/components/card/_index.scss
+++ b/src/lib/components/card/_index.scss
@@ -182,7 +182,6 @@
   transition: box-shadow $transitionSpeed, border-color $transitionSpeed;
 
   &:hover {
-    border-color: var(--vui-color-primary-highlight-shade);
     box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px;
   }
 }

--- a/src/lib/components/chat/_index.scss
+++ b/src/lib/components/chat/_index.scss
@@ -25,7 +25,7 @@ $minChatWidth: 600px;
   padding: $sizeXs $sizeS;
   font-size: $fontSizeStandard;
   color: var(--vui-color-text);
-  background-color: var(--vui-color-primary-lighter-shade);
+  background-color: var(--vui-color-primary-background);
   border: 1px solid var(--vui-color-border-medium);
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   transition: all $transitionSpeed;
@@ -104,7 +104,7 @@ $minChatWidth: 600px;
   padding: $sizeXs $sizeS;
   font-size: $fontSizeStandard;
   color: var(--vui-color-text);
-  background-color: var(--vui-color-primary-lighter-shade);
+  background-color: var(--vui-color-primary-background);
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
   // Ensure shadow overlaps on top of conversation.
   z-index: 2;

--- a/src/lib/components/chip/_index.scss
+++ b/src/lib/components/chip/_index.scss
@@ -68,6 +68,6 @@
     color: var(--vui-color-primary-shade);
   }
   .vuiChip__append {
-    background-color: var(--vui-color-primary-lighter-shade);
+    background-color: var(--vui-color-primary-background);
   }
 }

--- a/src/lib/components/complexConfigurationButton/_index.scss
+++ b/src/lib/components/complexConfigurationButton/_index.scss
@@ -1,6 +1,6 @@
 .vuiComplexConfigurationButton {
   width: 100%;
-  border: 1px solid var(--vui-color-primary-highlight-shade);
+  border: 1px solid var(--vui-color-border-light);
   padding: $sizeS $sizeM;
   border-radius: $sizeXs;
   transition: box-shadow $transitionSpeed, border-color $transitionSpeed;

--- a/src/lib/components/context/Theme.ts
+++ b/src/lib/components/context/Theme.ts
@@ -42,8 +42,6 @@ export type Theme = {
   colorDangerBackgroundRgb?: string;
 
   // Special colors
-  colorPrimaryHighlightShade?: string;
-  colorPrimaryHighlightShadeRgb?: string;
   colorSubduedShade?: string;
   colorSubduedShadeRgb?: string;
 
@@ -159,7 +157,6 @@ const colorDangerBorder = toRgba(colorDanger, 0.5);
 const colorDangerBackground = "#fceaeb";
 
 // Special colors
-const colorPrimaryHighlightShade = "#d9e2ff";
 const colorSubduedShade = "#6d7686";
 
 // Neutral colors
@@ -256,8 +253,6 @@ export const LIGHT_THEME: Theme = {
   colorDangerBackgroundRgb: toRgb(colorDangerBackground),
 
   // Special colors
-  colorPrimaryHighlightShade,
-  colorPrimaryHighlightShadeRgb: toRgb(colorPrimaryHighlightShade),
   colorSubduedShade,
   colorSubduedShadeRgb: toRgb(colorSubduedShade),
 
@@ -326,8 +321,6 @@ export const LIGHT_THEME: Theme = {
 
 export const DARK_THEME: Theme = {
   // Special colors
-  colorPrimaryHighlightShade,
-  colorPrimaryHighlightShadeRgb: toRgb(colorPrimaryHighlightShade),
   colorSubduedShade,
   colorSubduedShadeRgb: toRgb(colorSubduedShade),
 
@@ -403,8 +396,6 @@ export const toStyle = (theme: Theme) => {
     "--vui-color-danger-background-rgb": theme.colorDangerBackgroundRgb,
 
     // Special colors
-    "--vui-color-primary-highlight-shade": theme.colorPrimaryHighlightShade,
-    "--vui-color-primary-highlight-shade-rgb": theme.colorPrimaryHighlightShadeRgb,
     "--vui-color-subdued-shade": theme.colorSubduedShade,
     "--vui-color-subdued-shade-rgb": theme.colorSubduedShadeRgb,
 

--- a/src/lib/components/context/Theme.ts
+++ b/src/lib/components/context/Theme.ts
@@ -8,38 +8,38 @@ export type Theme = {
   // Semantic colors
   colorAccentShade?: string;
   colorAccentShadeRgb?: string;
-  colorAccentLightShade?: string;
-  colorAccentLightShadeRgb?: string;
-  colorAccentLighterShade?: string;
-  colorAccentLighterShadeRgb?: string;
+  colorAccentBorder?: string;
+  colorAccentBorderRgb?: string;
+  colorAccentBackground?: string;
+  colorAccentBackgroundRgb?: string;
 
   colorPrimaryShade?: string;
   colorPrimaryShadeRgb?: string;
-  colorPrimaryLightShade?: string;
-  colorPrimaryLightShadeRgb?: string;
-  colorPrimaryLighterShade?: string;
-  colorPrimaryLighterShadeRgb?: string;
+  colorPrimaryBorder?: string;
+  colorPrimaryBorderRgb?: string;
+  colorPrimaryBackground?: string;
+  colorPrimaryBackgroundRgb?: string;
 
   colorSuccessShade?: string;
   colorSuccessShadeRgb?: string;
-  colorSuccessLightShade?: string;
-  colorSuccessLightShadeRgb?: string;
-  colorSuccessLighterShade?: string;
-  colorSuccessLighterShadeRgb?: string;
+  colorSuccessBorder?: string;
+  colorSuccessBorderRgb?: string;
+  colorSuccessBackground?: string;
+  colorSuccessBackgroundRgb?: string;
 
   colorWarningShade?: string;
   colorWarningShadeRgb?: string;
-  colorWarningLightShade?: string;
-  colorWarningLightShadeRgb?: string;
-  colorWarningLighterShade?: string;
-  colorWarningLighterShadeRgb?: string;
+  colorWarningBorder?: string;
+  colorWarningBorderRgb?: string;
+  colorWarningBackground?: string;
+  colorWarningBackgroundRgb?: string;
 
   colorDangerShade?: string;
   colorDangerShadeRgb?: string;
-  colorDangerLightShade?: string;
-  colorDangerLightShadeRgb?: string;
-  colorDangerLighterShade?: string;
-  colorDangerLighterShadeRgb?: string;
+  colorDangerBorder?: string;
+  colorDangerBorderRgb?: string;
+  colorDangerBackground?: string;
+  colorDangerBackgroundRgb?: string;
 
   // Special colors
   colorPrimaryHighlightShade?: string;
@@ -139,24 +139,24 @@ const colorDanger = "#d22d2d";
 
 // Semantic colors
 const colorAccentShade = colorAccent;
-const colorAccentLightShade = toRgba(colorAccent, 0.5);
-const colorAccentLighterShade = "#eee7ff";
+const colorAccentBorder = toRgba(colorAccent, 0.5);
+const colorAccentBackground = "#efeaf9";
 
 const colorPrimaryShade = colorPrimary;
-const colorPrimaryLightShade = toRgba(colorPrimary, 0.5);
-const colorPrimaryLighterShade = "#f1f7ff";
+const colorPrimaryBorder = toRgba(colorPrimary, 0.5);
+const colorPrimaryBackground = "#e8eefb";
 
 const colorSuccessShade = colorSuccess;
-const colorSuccessLightShade = toRgba(colorSuccess, 0.5);
-const colorSuccessLighterShade = "#e2f2e0";
+const colorSuccessBorder = toRgba(colorSuccess, 0.5);
+const colorSuccessBackground = "#ebf4e9";
 
 const colorWarningShade = colorWarning;
-const colorWarningLightShade = toRgba(colorWarning, 0.5);
-const colorWarningLighterShade = "#ffeed4";
+const colorWarningBorder = toRgba(colorWarning, 0.5);
+const colorWarningBackground = "#f6f1e9";
 
 const colorDangerShade = colorDanger;
-const colorDangerLightShade = toRgba(colorDanger, 0.5);
-const colorDangerLighterShade = "#fff1f1";
+const colorDangerBorder = toRgba(colorDanger, 0.5);
+const colorDangerBackground = "#fceaeb";
 
 // Special colors
 const colorPrimaryHighlightShade = "#d9e2ff";
@@ -222,38 +222,38 @@ export const LIGHT_THEME: Theme = {
   // Semantic colors
   colorAccentShade,
   colorAccentShadeRgb: toRgb(colorAccentShade),
-  colorAccentLightShade,
-  colorAccentLightShadeRgb: toRgb(colorAccentLightShade),
-  colorAccentLighterShade,
-  colorAccentLighterShadeRgb: toRgb(colorAccentLighterShade),
+  colorAccentBorder,
+  colorAccentBorderRgb: toRgb(colorAccentBorder),
+  colorAccentBackground,
+  colorAccentBackgroundRgb: toRgb(colorAccentBackground),
 
   colorPrimaryShade,
   colorPrimaryShadeRgb: toRgb(colorPrimaryShade),
-  colorPrimaryLightShade,
-  colorPrimaryLightShadeRgb: toRgb(colorPrimaryLightShade),
-  colorPrimaryLighterShade,
-  colorPrimaryLighterShadeRgb: toRgb(colorPrimaryLighterShade),
+  colorPrimaryBorder,
+  colorPrimaryBorderRgb: toRgb(colorPrimaryBorder),
+  colorPrimaryBackground,
+  colorPrimaryBackgroundRgb: toRgb(colorPrimaryBackground),
 
   colorSuccessShade,
   colorSuccessShadeRgb: toRgb(colorSuccessShade),
-  colorSuccessLightShade,
-  colorSuccessLightShadeRgb: toRgb(colorSuccessLightShade),
-  colorSuccessLighterShade,
-  colorSuccessLighterShadeRgb: toRgb(colorSuccessLighterShade),
+  colorSuccessBorder,
+  colorSuccessBorderRgb: toRgb(colorSuccessBorder),
+  colorSuccessBackground,
+  colorSuccessBackgroundRgb: toRgb(colorSuccessBackground),
 
   colorWarningShade,
   colorWarningShadeRgb: toRgb(colorWarningShade),
-  colorWarningLightShade,
-  colorWarningLightShadeRgb: toRgb(colorWarningLightShade),
-  colorWarningLighterShade,
-  colorWarningLighterShadeRgb: toRgb(colorWarningLighterShade),
+  colorWarningBorder,
+  colorWarningBorderRgb: toRgb(colorWarningBorder),
+  colorWarningBackground,
+  colorWarningBackgroundRgb: toRgb(colorWarningBackground),
 
   colorDangerShade,
   colorDangerShadeRgb: toRgb(colorDangerShade),
-  colorDangerLightShade,
-  colorDangerLightShadeRgb: toRgb(colorDangerLightShade),
-  colorDangerLighterShade,
-  colorDangerLighterShadeRgb: toRgb(colorDangerLighterShade),
+  colorDangerBorder,
+  colorDangerBorderRgb: toRgb(colorDangerBorder),
+  colorDangerBackground,
+  colorDangerBackgroundRgb: toRgb(colorDangerBackground),
 
   // Special colors
   colorPrimaryHighlightShade,
@@ -369,38 +369,38 @@ export const toStyle = (theme: Theme) => {
     // Semantic colors
     "--vui-color-accent-shade": theme.colorAccentShade,
     "--vui-color-accent-shade-rgb": theme.colorAccentShadeRgb,
-    "--vui-color-accent-light-shade": theme.colorAccentLightShade,
-    "--vui-color-accent-light-shade-rgb": theme.colorAccentLightShadeRgb,
-    "--vui-color-accent-lighter-shade": theme.colorAccentLighterShade,
-    "--vui-color-accent-lighter-shade-rgb": theme.colorAccentLighterShadeRgb,
+    "--vui-color-accent-border": theme.colorAccentBorder,
+    "--vui-color-accent-border-rgb": theme.colorAccentBorderRgb,
+    "--vui-color-accent-background": theme.colorAccentBackground,
+    "--vui-color-accent-background-rgb": theme.colorAccentBackgroundRgb,
 
     "--vui-color-primary-shade": theme.colorPrimaryShade,
     "--vui-color-primary-shade-rgb": theme.colorPrimaryShadeRgb,
-    "--vui-color-primary-light-shade": theme.colorPrimaryLightShade,
-    "--vui-color-primary-light-shade-rgb": theme.colorPrimaryLightShadeRgb,
-    "--vui-color-primary-lighter-shade": theme.colorPrimaryLighterShade,
-    "--vui-color-primary-lighter-shade-rgb": theme.colorPrimaryLighterShadeRgb,
+    "--vui-color-primary-border": theme.colorPrimaryBorder,
+    "--vui-color-primary-border-rgb": theme.colorPrimaryBorderRgb,
+    "--vui-color-primary-background": theme.colorPrimaryBackground,
+    "--vui-color-primary-background-rgb": theme.colorPrimaryBackgroundRgb,
 
     "--vui-color-success-shade": theme.colorSuccessShade,
     "--vui-color-success-shade-rgb": theme.colorSuccessShadeRgb,
-    "--vui-color-success-light-shade": theme.colorSuccessLightShade,
-    "--vui-color-success-light-shade-rgb": theme.colorSuccessLightShadeRgb,
-    "--vui-color-success-lighter-shade": theme.colorSuccessLighterShade,
-    "--vui-color-success-lighter-shade-rgb": theme.colorSuccessLighterShadeRgb,
+    "--vui-color-success-border": theme.colorSuccessBorder,
+    "--vui-color-success-border-rgb": theme.colorSuccessBorderRgb,
+    "--vui-color-success-background": theme.colorSuccessBackground,
+    "--vui-color-success-background-rgb": theme.colorSuccessBackgroundRgb,
 
     "--vui-color-warning-shade": theme.colorWarningShade,
     "--vui-color-warning-shade-rgb": theme.colorWarningShadeRgb,
-    "--vui-color-warning-light-shade": theme.colorWarningLightShade,
-    "--vui-color-warning-light-shade-rgb": theme.colorWarningLightShadeRgb,
-    "--vui-color-warning-lighter-shade": theme.colorWarningLighterShade,
-    "--vui-color-warning-lighter-shade-rgb": theme.colorWarningLighterShadeRgb,
+    "--vui-color-warning-border": theme.colorWarningBorder,
+    "--vui-color-warning-border-rgb": theme.colorWarningBorderRgb,
+    "--vui-color-warning-background": theme.colorWarningBackground,
+    "--vui-color-warning-background-rgb": theme.colorWarningBackgroundRgb,
 
     "--vui-color-danger-shade": theme.colorDangerShade,
     "--vui-color-danger-shade-rgb": theme.colorDangerShadeRgb,
-    "--vui-color-danger-light-shade": theme.colorDangerLightShade,
-    "--vui-color-danger-light-shade-rgb": theme.colorDangerLightShadeRgb,
-    "--vui-color-danger-lighter-shade": theme.colorDangerLighterShade,
-    "--vui-color-danger-lighter-shade-rgb": theme.colorDangerLighterShadeRgb,
+    "--vui-color-danger-border": theme.colorDangerBorder,
+    "--vui-color-danger-border-rgb": theme.colorDangerBorderRgb,
+    "--vui-color-danger-background": theme.colorDangerBackground,
+    "--vui-color-danger-background-rgb": theme.colorDangerBackgroundRgb,
 
     // Special colors
     "--vui-color-primary-highlight-shade": theme.colorPrimaryHighlightShade,
@@ -433,6 +433,13 @@ export const toStyle = (theme: Theme) => {
     "--vui-color-border-medium-rgb": theme.colorBorderMediumRgb,
     "--vui-color-border-light": theme.colorBorderLight,
     "--vui-color-border-light-rgb": theme.colorBorderLightRgb,
+
+    // Semantic colors mapped to categorical.
+    "--vui-color-accent-text": theme.colorAccentShade,
+    "--vui-color-primary-text": theme.colorPrimaryShade,
+    "--vui-color-success-text": theme.colorSuccessShade,
+    "--vui-color-warning-text": theme.colorWarningShade,
+    "--vui-color-danger-text": theme.colorDangerShade,
 
     // Categorical colors
     "--vui-color-indigo-background": theme.colorIndigoBackground,

--- a/src/lib/components/form/superCheckboxGroup/_index.scss
+++ b/src/lib/components/form/superCheckboxGroup/_index.scss
@@ -16,7 +16,7 @@
   &:hover {
     text-decoration: underline;
     text-decoration-color: var(--vui-color-primary-shade);
-    background-color: var(--vui-color-primary-lighter-shade);
+    background-color: var(--vui-color-primary-background);
 
     .vuiSuperCheckbox__text {
       color: var(--vui-color-primary-shade) !important;

--- a/src/lib/components/form/superRadioGroup/_index.scss
+++ b/src/lib/components/form/superRadioGroup/_index.scss
@@ -16,7 +16,7 @@
   &:hover {
     text-decoration: underline;
     text-decoration-color: var(--vui-color-primary-shade);
-    background-color: var(--vui-color-primary-lighter-shade);
+    background-color: var(--vui-color-primary-background);
 
     .vuiSuperRadioButton__text {
       color: var(--vui-color-primary-shade) !important;

--- a/src/lib/components/icon/_index.scss
+++ b/src/lib/components/icon/_index.scss
@@ -14,27 +14,27 @@ $color: (
   accent: (
     "icon": var(--vui-color-accent-shade),
     "fill": var(--vui-color-accent-shade),
-    "token": var(--vui-color-accent-lighter-shade)
+    "token": var(--vui-color-accent-background)
   ),
   primary: (
     "icon": var(--vui-color-primary-shade),
     "fill": var(--vui-color-primary-shade),
-    "token": var(--vui-color-primary-lighter-shade)
+    "token": var(--vui-color-primary-background)
   ),
   success: (
     "icon": var(--vui-color-success-shade),
     "fill": var(--vui-color-success-shade),
-    "token": var(--vui-color-success-lighter-shade)
+    "token": var(--vui-color-success-background)
   ),
   warning: (
     "icon": var(--vui-color-warning-shade),
     "fill": var(--vui-color-warning-shade),
-    "token": var(--vui-color-warning-lighter-shade)
+    "token": var(--vui-color-warning-background)
   ),
   danger: (
     "icon": var(--vui-color-danger-shade),
     "fill": var(--vui-color-danger-shade),
-    "token": var(--vui-color-danger-lighter-shade)
+    "token": var(--vui-color-danger-background)
   ),
   subdued: (
     "icon": var(--vui-color-subdued-shade),
@@ -65,11 +65,11 @@ $colors: (
 );
 
 $tokenColors: (
-  accent: var(--vui-color-accent-lighter-shade),
-  primary: var(--vui-color-primary-lighter-shade),
-  success: var(--vui-color-success-lighter-shade),
-  warning: var(--vui-color-warning-lighter-shade),
-  danger: var(--vui-color-danger-lighter-shade),
+  accent: var(--vui-color-accent-background),
+  primary: var(--vui-color-primary-background),
+  success: var(--vui-color-success-background),
+  warning: var(--vui-color-warning-background),
+  danger: var(--vui-color-danger-background),
   subdued: var(--vui-color-medium-shade),
   neutral: var(--vui-color-dark-shade),
   empty: #ffffff

--- a/src/lib/components/image/_index.scss
+++ b/src/lib/components/image/_index.scss
@@ -32,7 +32,7 @@
   border-radius: $sizeXxs;
 
   &--error {
-    background-color: var(--vui-color-danger-lighter-shade);
+    background-color: var(--vui-color-danger-background);
 
     p {
       color: var(--vui-color-danger-shade);

--- a/src/lib/components/list/_index.scss
+++ b/src/lib/components/list/_index.scss
@@ -24,6 +24,6 @@
 }
 
 .vuiListNumber-isComplete {
-  background-color: var(--vui-color-accent-lighter-shade);
+  background-color: var(--vui-color-accent-background);
   color: var(--vui-color-accent-shade);
 }

--- a/src/lib/components/menu/_index.scss
+++ b/src/lib/components/menu/_index.scss
@@ -31,17 +31,17 @@
 $color: (
   neutral: (
     "color": var(--vui-color-text),
-    "background-color": var(--vui-color-primary-lighter-shade),
+    "background-color": var(--vui-color-primary-background),
     "hover-color": var(--vui-color-primary-shade)
   ),
   primary: (
     "color": var(--vui-color-primary-shade),
-    "background-color": var(--vui-color-primary-lighter-shade),
+    "background-color": var(--vui-color-primary-background),
     "hover-color": var(--vui-color-primary-shade)
   ),
   danger: (
     "color": var(--vui-color-danger-shade),
-    "background-color": var(--vui-color-danger-lighter-shade),
+    "background-color": var(--vui-color-danger-background),
     "hover-color": var(--vui-color-danger-shade)
   )
 );

--- a/src/lib/components/optionsList/_index.scss
+++ b/src/lib/components/optionsList/_index.scss
@@ -47,32 +47,32 @@ $color: (
   accent: (
     "color": var(--vui-color-accent-shade),
     "hover-color": var(--vui-color-accent-shade),
-    "selected-color": var(--vui-color-accent-lighter-shade)
+    "selected-color": var(--vui-color-accent-background)
   ),
   primary: (
     "color": var(--vui-color-primary-shade),
     "hover-color": var(--vui-color-primary-shade),
-    "selected-color": var(--vui-color-primary-lighter-shade)
+    "selected-color": var(--vui-color-primary-background)
   ),
   success: (
     "color": var(--vui-color-success-shade),
     "hover-color": var(--vui-color-success-shade),
-    "selected-color": var(--vui-color-success-lighter-shade)
+    "selected-color": var(--vui-color-success-background)
   ),
   danger: (
     "color": var(--vui-color-danger-shade),
     "hover-color": var(--vui-color-danger-shade),
-    "selected-color": var(--vui-color-danger-lighter-shade)
+    "selected-color": var(--vui-color-danger-background)
   ),
   warning: (
     "color": var(--vui-color-warning-shade),
     "hover-color": var(--vui-color-warning-shade),
-    "selected-color": var(--vui-color-warning-lighter-shade)
+    "selected-color": var(--vui-color-warning-background)
   ),
   neutral: (
     "color": var(--vui-color-text),
     "hover-color": var(--vui-color-primary-shade),
-    "selected-color": var(--vui-color-primary-lighter-shade)
+    "selected-color": var(--vui-color-primary-background)
   )
 );
 

--- a/src/lib/components/patch/VuiPatch.tsx
+++ b/src/lib/components/patch/VuiPatch.tsx
@@ -1,6 +1,11 @@
 import classNames from "classnames";
 
 export const PATCH_COLOR = [
+  "primary",
+  "accent",
+  "success",
+  "warning",
+  "danger",
   "red",
   "orange",
   "amber",

--- a/src/lib/components/patch/_index.scss
+++ b/src/lib/components/patch/_index.scss
@@ -6,7 +6,8 @@
   justify-content: center;
 }
 
-$colors: "indigo", "emerald", "amber", "pink", "sky", "orange", "slate", "teal", "lime", "purple", "fuchsia", "red";
+$colors: "primary", "accent", "success", "warning", "danger", "indigo", "emerald", "amber", "pink", "sky", "orange",
+  "slate", "teal", "lime", "purple", "fuchsia", "red";
 
 @each $color in $colors {
   .vuiPatch--#{$color} {

--- a/src/lib/components/progressBar/_index.scss
+++ b/src/lib/components/progressBar/_index.scss
@@ -35,19 +35,19 @@
 // Color
 $color: (
   accent: (
-    "background-color": linear-gradient(to top, var(--vui-color-accent-shade), var(--vui-color-accent-light-shade))
+    "background-color": linear-gradient(to top, var(--vui-color-accent-shade), var(--vui-color-accent-border))
   ),
   primary: (
-    "background-color": linear-gradient(to top, var(--vui-color-primary-shade), var(--vui-color-primary-light-shade))
+    "background-color": linear-gradient(to top, var(--vui-color-primary-shade), var(--vui-color-primary-border))
   ),
   success: (
-    "background-color": linear-gradient(to top, var(--vui-color-success-shade), var(--vui-color-success-light-shade))
+    "background-color": linear-gradient(to top, var(--vui-color-success-shade), var(--vui-color-success-border))
   ),
   warning: (
-    "background-color": linear-gradient(to top, var(--vui-color-warning-shade), var(--vui-color-warning-light-shade))
+    "background-color": linear-gradient(to top, var(--vui-color-warning-shade), var(--vui-color-warning-border))
   ),
   danger: (
-    "background-color": linear-gradient(to top, var(--vui-color-danger-shade), var(--vui-color-danger-light-shade))
+    "background-color": linear-gradient(to top, var(--vui-color-danger-shade), var(--vui-color-danger-border))
   ),
   neutral: (
     "background-color": linear-gradient(to top, var(--vui-color-dark-shade), var(--vui-color-medium-shade))

--- a/src/lib/components/prompt/_index.scss
+++ b/src/lib/components/prompt/_index.scss
@@ -29,7 +29,7 @@
 
 .vuiPrompt--interactive {
   &:hover {
-    background-color: var(--vui-color-accent-lighter-shade);
+    background-color: var(--vui-color-accent-background);
     color: var(--vui-color-accent-shade);
   }
 }
@@ -38,7 +38,7 @@
 $color: (
   danger: (
     "color": var(--vui-color-danger-shade),
-    "background-color": var(--vui-color-danger-lighter-shade)
+    "background-color": var(--vui-color-danger-background)
   ),
   neutral: (
     "color": var(--vui-color-dark-shade),

--- a/src/lib/components/searchInput/_index.scss
+++ b/src/lib/components/searchInput/_index.scss
@@ -165,7 +165,7 @@
   &:hover {
     text-decoration: underline;
     color: var(--vui-color-primary-shade);
-    background-color: var(--vui-color-primary-lighter-shade);
+    background-color: var(--vui-color-primary-background);
   }
 
   &:focus-visible {

--- a/src/lib/components/skeleton/_index.scss
+++ b/src/lib/components/skeleton/_index.scss
@@ -39,19 +39,19 @@
 // Color variants
 $color: (
   accent: (
-    "backgroundColor": var(--vui-color-accent-lighter-shade)
+    "backgroundColor": var(--vui-color-accent-background)
   ),
   primary: (
-    "backgroundColor": var(--vui-color-primary-lighter-shade)
+    "backgroundColor": var(--vui-color-primary-background)
   ),
   success: (
-    "backgroundColor": var(--vui-color-success-lighter-shade)
+    "backgroundColor": var(--vui-color-success-background)
   ),
   danger: (
-    "backgroundColor": var(--vui-color-danger-lighter-shade)
+    "backgroundColor": var(--vui-color-danger-background)
   ),
   warning: (
-    "backgroundColor": var(--vui-color-warning-lighter-shade)
+    "backgroundColor": var(--vui-color-warning-background)
   ),
   neutral: (
     "backgroundColor": var(--vui-color-medium-shade)

--- a/src/lib/components/steps/_index.scss
+++ b/src/lib/components/steps/_index.scss
@@ -115,7 +115,7 @@ $stepSizeM: 36px;
   }
 
   &--complete {
-    background-color: var(--vui-color-success-lighter-shade);
+    background-color: var(--vui-color-success-background);
   }
 
   &--current {
@@ -134,11 +134,11 @@ $stepSizeM: 36px;
   }
 
   &--warning {
-    background-color: var(--vui-color-warning-lighter-shade);
+    background-color: var(--vui-color-warning-background);
   }
 
   &--danger {
-    background-color: var(--vui-color-danger-lighter-shade);
+    background-color: var(--vui-color-danger-background);
   }
 }
 

--- a/src/lib/components/summary/_index.scss
+++ b/src/lib/components/summary/_index.scss
@@ -18,7 +18,7 @@
 
   &:hover {
     color: var(--vui-color-primary-shade);
-    background-color: var(--vui-color-primary-lighter-shade);
+    background-color: var(--vui-color-primary-background);
     text-decoration: underline;
   }
 }

--- a/src/lib/components/tabs/_open.scss
+++ b/src/lib/components/tabs/_open.scss
@@ -25,7 +25,7 @@
     &:hover {
       .vuiTab__inner {
         color: var(--vui-color-primary-shade);
-        background-color: var(--vui-color-primary-lighter-shade);
+        background-color: var(--vui-color-primary-background);
 
         .vuiIcon__inner {
           color: var(--vui-color-primary-shade) !important;


### PR DESCRIPTION
This is a breaking change for a consumer that configures any of these Theme vars:

* colorAccentLightShade
* colorAccentLightShadeRgb
* colorAccentLighterShade
* colorAccentLighterShadeRgb
* colorPrimaryLightShade
* colorPrimaryLightShadeRgb
* colorPrimaryLighterShade
* colorPrimaryLighterShadeRgb
* colorSuccessLightShade
* colorSuccessLightShadeRgb
* colorSuccessLighterShade
* colorSuccessLighterShadeRgb
* colorWarningLightShade
* colorWarningLightShadeRgb
* colorWarningLighterShade
* colorWarningLighterShadeRgb
* colorDangerLightShade
* colorDangerLightShadeRgb
* colorDangerLighterShade
* colorDangerLighterShadeRgb
* colorPrimaryHighlightShade
* colorPrimaryHighlightShadeRgb

It's also a breaking change for a consumer that consumes these corresponding CSS vars:

* --vui-color-accent-light-shade
* --vui-color-accent-light-shade-rgb
* --vui-color-accent-lighter-shade
* --vui-color-accent-lighter-shade-rgb
* --vui-color-primary-light-shade
* --vui-color-primary-light-shade-rgb
* --vui-color-primary-lighter-shade
* --vui-color-primary-lighter-shade-rgb
* --vui-color-success-light-shade
* --vui-color-success-light-shade-rgb
* --vui-color-success-lighter-shade
* --vui-color-success-lighter-shade-rgb
* --vui-color-warning-light-shade
* --vui-color-warning-light-shade-rgb
* --vui-color-warning-lighter-shade
* --vui-color-warning-lighter-shade-rgb
* --vui-color-danger-light-shade
* --vui-color-danger-light-shade-rgb
* --vui-color-danger-lighter-shade
* --vui-color-danger-lighter-shade-rgb
* --vui-color-primary-highlight-shade
* --vui-color-primary-highlight-shade-rgb