### PR TITLE
Cleaner ui for multiline labels for the VuiStatus

### DIFF
--- a/src/docs/pages/status/Status.tsx
+++ b/src/docs/pages/status/Status.tsx
@@ -1,4 +1,4 @@
-import { VuiSpacer, VuiStatus } from "../../../lib";
+import { VuiSpacer, VuiStatus, VuiTitle } from "../../../lib";
 
 export const Status = () => {
   return (
@@ -17,7 +17,45 @@ export const Status = () => {
 
       <VuiStatus status="info" label="Info" />
 
-      <VuiSpacer size="m" />
+      <VuiSpacer size="l" />
+
+      <div style={{ width: "300px" }}>
+        <VuiTitle size="s">
+          <h3>Multiline message</h3>
+        </VuiTitle>
+
+        <VuiSpacer size="m" />
+
+        <VuiStatus
+          status="error"
+          label="A multiline error message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
+          gap="l"
+        />
+
+        <VuiSpacer size="m" />
+
+        <VuiStatus
+          status="warning"
+          label="A multiline warning message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
+          gap="l"
+        />
+
+        <VuiSpacer size="m" />
+
+        <VuiStatus
+          status="success"
+          label="A multiline success message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
+          gap="l"
+        />
+
+        <VuiSpacer size="m" />
+
+        <VuiStatus
+          status="info"
+          label="A multiline info message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
+          gap="l"
+        />
+      </div>
     </>
   );
 };

--- a/src/docs/pages/status/Status.tsx
+++ b/src/docs/pages/status/Status.tsx
@@ -30,6 +30,7 @@ export const Status = () => {
           status="error"
           label="A multiline error message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
           gap="l"
+          align="start"
         />
 
         <VuiSpacer size="m" />
@@ -38,6 +39,7 @@ export const Status = () => {
           status="warning"
           label="A multiline warning message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
           gap="l"
+          align="start"
         />
 
         <VuiSpacer size="m" />
@@ -46,6 +48,7 @@ export const Status = () => {
           status="success"
           label="A multiline success message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
           gap="l"
+          align="start"
         />
 
         <VuiSpacer size="m" />
@@ -54,6 +57,7 @@ export const Status = () => {
           status="info"
           label="A multiline info message. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis placerat sem, ut mattis sapien."
           gap="l"
+          align="start"
         />
       </div>
     </>

--- a/src/lib/components/flex/FlexContainer.tsx
+++ b/src/lib/components/flex/FlexContainer.tsx
@@ -1,30 +1,30 @@
 import { ReactNode } from "react";
 import classNames from "classnames";
-import { FlexSpacing } from "./types";
+import { AlignItemsPosition, FlexDirection, FlexSpacing, JustifyContentPosition } from "./types";
 
-const alignItemsToClassNameMap = {
+const alignItemsToClassNameMap: Record<AlignItemsPosition, string> = {
   baseline: "vuiFlexContainer--alignItemsBaseline",
   center: "vuiFlexContainer--alignItemsCenter",
   end: "vuiFlexContainer--alignItemsEnd",
   start: "vuiFlexContainer--alignItemsStart",
   stretch: "vuiFlexContainer--alignItemsStretch"
-} as const;
+};
 
-const directionToClassNameMap = {
+const directionToClassNameMap: Record<FlexDirection, string> = {
   column: "vuiFlexContainer--directionColumn",
   columnReverse: "vuiFlexContainer--directionColumnReverse",
   row: "vuiFlexContainer--directionRow",
   rowReverse: "vuiFlexContainer--directionRowReverse"
-} as const;
+};
 
-const justifyContentToClassNameMap = {
+const justifyContentToClassNameMap: Record<JustifyContentPosition, string> = {
   center: "vuiFlexContainer--justifyContentCenter",
   end: "vuiFlexContainer--justifyContentEnd",
   start: "vuiFlexContainer--justifyContentStart",
   spaceAround: "vuiFlexContainer--justifyContentSpaceAround",
   spaceBetween: "vuiFlexContainer--justifyContentSpaceBetween",
   spaceEvenly: "vuiFlexContainer--justifyContentSpaceEvenly"
-} as const;
+};
 
 const spacingToClassNameMap: Record<FlexSpacing, string> = {
   none: "vuiFlexContainer--spacingNone",
@@ -35,13 +35,13 @@ const spacingToClassNameMap: Record<FlexSpacing, string> = {
   l: "vuiFlexContainer--spacingL",
   xl: "vuiFlexContainer--spacingXl",
   xxl: "vuiFlexContainer--spacingXxl"
-} as const;
+};
 
 export type Props = {
   children?: ReactNode;
-  alignItems?: keyof typeof alignItemsToClassNameMap;
-  direction?: keyof typeof directionToClassNameMap;
-  justifyContent?: keyof typeof justifyContentToClassNameMap;
+  alignItems?: AlignItemsPosition;
+  direction?: FlexDirection;
+  justifyContent?: JustifyContentPosition;
   spacing?: FlexSpacing;
   wrap?: boolean;
   className?: string;

--- a/src/lib/components/flex/types.ts
+++ b/src/lib/components/flex/types.ts
@@ -1,2 +1,18 @@
 export const FLEX_SPACING = ["none", "xxs", "xs", "s", "m", "l", "xl", "xxl"] as const;
 export type FlexSpacing = (typeof FLEX_SPACING)[number];
+
+export const ALIGN_ITEMS_POSITION = ["baseline", "center", "end", "start", "stretch"] as const;
+export type AlignItemsPosition = (typeof ALIGN_ITEMS_POSITION)[number];
+
+export const FLEX_DIRECTION = ["column", "columnReverse", "row", "rowReverse"] as const;
+export type FlexDirection = (typeof FLEX_DIRECTION)[number];
+
+export const JUSTIFY_CONTENT_POSITION = [
+  "center",
+  "end",
+  "start",
+  "spaceAround",
+  "spaceBetween",
+  "spaceEvenly"
+] as const;
+export type JustifyContentPosition = (typeof JUSTIFY_CONTENT_POSITION)[number];

--- a/src/lib/components/status/Status.tsx
+++ b/src/lib/components/status/Status.tsx
@@ -1,6 +1,7 @@
 import { BiCheck, BiError, BiInfoCircle, BiSolidHand } from "react-icons/bi";
 import { VuiFlexContainer } from "../flex/FlexContainer";
 import { VuiFlexItem } from "../flex/FlexItem";
+import { FlexSpacing } from "../flex/types";
 import { VuiIcon } from "../icon/Icon";
 import { VuiText } from "../typography/Text";
 import { VuiTextColor } from "../typography/TextColor";
@@ -8,6 +9,7 @@ import { VuiTextColor } from "../typography/TextColor";
 type Props = {
   status: "error" | "warning" | "success" | "info";
   label: string;
+  gap?: FlexSpacing;
 };
 
 const statusToColor = {
@@ -24,12 +26,12 @@ const statusToIcon = {
   info: <BiInfoCircle />
 } as const;
 
-export const VuiStatus = ({ status, label }: Props) => {
+export const VuiStatus = ({ status, label, gap = "xs" }: Props) => {
   const color = statusToColor[status];
   const icon = statusToIcon[status];
 
   return (
-    <VuiFlexContainer alignItems="center" spacing="xs">
+    <VuiFlexContainer alignItems="start" spacing={gap}>
       <VuiFlexItem grow={false}>
         <VuiIcon color={color}>{icon}</VuiIcon>
       </VuiFlexItem>

--- a/src/lib/components/status/Status.tsx
+++ b/src/lib/components/status/Status.tsx
@@ -1,7 +1,7 @@
 import { BiCheck, BiError, BiInfoCircle, BiSolidHand } from "react-icons/bi";
 import { VuiFlexContainer } from "../flex/FlexContainer";
 import { VuiFlexItem } from "../flex/FlexItem";
-import { FlexSpacing } from "../flex/types";
+import { AlignItemsPosition, FlexSpacing } from "../flex/types";
 import { VuiIcon } from "../icon/Icon";
 import { VuiText } from "../typography/Text";
 import { VuiTextColor } from "../typography/TextColor";
@@ -10,6 +10,7 @@ type Props = {
   status: "error" | "warning" | "success" | "info";
   label: string;
   gap?: FlexSpacing;
+  align?: AlignItemsPosition;
 };
 
 const statusToColor = {
@@ -26,12 +27,12 @@ const statusToIcon = {
   info: <BiInfoCircle />
 } as const;
 
-export const VuiStatus = ({ status, label, gap = "xs" }: Props) => {
+export const VuiStatus = ({ status, label, gap = "xs", align = "center" }: Props) => {
   const color = statusToColor[status];
   const icon = statusToIcon[status];
 
   return (
-    <VuiFlexContainer alignItems="start" spacing={gap}>
+    <VuiFlexContainer alignItems={align} spacing={gap}>
       <VuiFlexItem grow={false}>
         <VuiIcon color={color}>{icon}</VuiIcon>
       </VuiFlexItem>


### PR DESCRIPTION
Issue: A multiline label for the `VuiStatus` sticks the icon and the text. 

<img width="413" height="89" alt="image" src="https://github.com/user-attachments/assets/89b10381-f97c-41c3-8aea-9b4d982831a6" />

Solution:
Control layout with align and gap props.

<img width="391" height="759" alt="Screenshot 2026-06-25 at 6 07 04 PM" src="https://github.com/user-attachments/assets/e8ef7854-8c9c-440c-b278-568ef9600d8c" />
