### PR TITLE
feat: extend progress indicators for VuiSimpleCard and VuiTable

### DIFF
--- a/src/docs/pages.tsx
+++ b/src/docs/pages.tsx
@@ -39,6 +39,7 @@ import { label } from "./pages/label";
 import { lineChart } from "./pages/lineChart";
 import { link } from "./pages/link";
 import { list } from "./pages/list";
+import { loadingBar } from "./pages/loadingBar";
 import { menu } from "./pages/menu";
 import { modal } from "./pages/modal";
 import { notifications } from "./pages/notifications";
@@ -126,6 +127,7 @@ export const categories: Category[] = [
       icon,
       image,
       inProgress,
+      loadingBar,
       progressBar,
       spinner,
       skeleton,

--- a/src/docs/pages/card/SimpleCard.tsx
+++ b/src/docs/pages/card/SimpleCard.tsx
@@ -148,6 +148,20 @@ export const SimpleCard = () => {
             </p>
           </VuiText>
         </VuiSimpleCard>
+
+        <VuiSimpleCard padding={padding} isLoading>
+          <VuiTitle size="xs">
+            <h3>Beaver</h3>
+          </VuiTitle>
+
+          <VuiSpacer size="xxs" />
+
+          <VuiText>
+            <p>
+              <VuiTextColor color="subdued">Busy, industrious, still building</VuiTextColor>
+            </p>
+          </VuiText>
+        </VuiSimpleCard>
       </VuiGrid>
 
       <VuiSpacer size="m" />

--- a/src/docs/pages/loadingBar/LoadingBar.tsx
+++ b/src/docs/pages/loadingBar/LoadingBar.tsx
@@ -1,0 +1,39 @@
+import { VuiLoadingBar, VuiSpacer, VuiText } from "../../../lib";
+import { LOADING_BAR_COLOR } from "../../../lib/components/loadingBar/LoadingBar";
+
+export const LoadingBar = () => {
+  return (
+    <>
+      <VuiText>
+        <p>
+          The loading bar anchors to the bottom edge of its nearest positioned ancestor, so it can signal background
+          activity inside any container without disturbing its content.
+        </p>
+      </VuiText>
+
+      <VuiSpacer size="m" />
+
+      {LOADING_BAR_COLOR.map((color) => (
+        <div key={color}>
+          <div
+            style={{
+              position: "relative",
+              overflow: "hidden",
+              border: "1px solid var(--vui-color-border-light)",
+              borderRadius: "8px",
+              padding: "16px"
+            }}
+          >
+            <VuiText>
+              <p>{color}</p>
+            </VuiText>
+
+            <VuiLoadingBar color={color} />
+          </div>
+
+          <VuiSpacer size="s" />
+        </div>
+      ))}
+    </>
+  );
+};

--- a/src/docs/pages/loadingBar/index.tsx
+++ b/src/docs/pages/loadingBar/index.tsx
@@ -1,0 +1,11 @@
+import { LoadingBar } from "./LoadingBar";
+const LoadingBarSource = require("!!raw-loader!./LoadingBar");
+
+export const loadingBar = {
+  name: "Loading Bar",
+  path: "/loadingBar",
+  example: {
+    component: <LoadingBar />,
+    source: LoadingBarSource.default.toString()
+  }
+};

--- a/src/docs/pages/table/Table.tsx
+++ b/src/docs/pages/table/Table.tsx
@@ -33,6 +33,7 @@ export const Table = () => {
   const [isHeaderSticky, setIsHeaderSticky] = useState(false);
   const [isResponsive, setIsResponsive] = useState(true);
   const [hasExpandableRows, setHasExpandableRows] = useState(true);
+  const [hasStatusIndicator, setHasStatusIndicator] = useState(false);
 
   // Table state
   const [isLoading, setIsLoading] = useState(true);
@@ -400,6 +401,14 @@ export const Table = () => {
             onChange={(e) => setHasExpandableRows(e.target.checked)}
           />
         </VuiFlexItem>
+
+        <VuiFlexItem shrink={false}>
+          <VuiToggle
+            label="Has status indicator"
+            checked={hasStatusIndicator}
+            onChange={(e) => setHasStatusIndicator(e.target.checked)}
+          />
+        </VuiFlexItem>
       </VuiFlexContainer>
 
       <VuiSpacer size="xl" />
@@ -423,6 +432,13 @@ export const Table = () => {
         activeRowId={activeRowId}
         onSort={handleSort}
         onReload={onReload}
+        statusIndicator={
+          hasStatusIndicator ? (
+            <VuiBadge color={isLoading ? "primary" : "success"}>
+              {isLoading ? "Updating" : "Up to date"}
+            </VuiBadge>
+          ) : undefined
+        }
         search={search}
         customControls={
           <VuiSelect

--- a/src/lib/components/card/SimpleCard.tsx
+++ b/src/lib/components/card/SimpleCard.tsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import { ReactNode, MouseEvent } from "react";
 import { useVuiContext } from "../context/Context";
+import { VuiLoadingBar } from "../loadingBar/LoadingBar";
 import { VuiSpacer } from "../spacer/Spacer";
 import { VuiStatus } from "../status/Status";
 
@@ -13,6 +14,8 @@ type Props = {
   children?: React.ReactNode;
   error?: string | ReactNode;
   warning?: string | ReactNode;
+  isLoading?: boolean;
+  loadingIndicator?: ReactNode;
 };
 
 export const VuiSimpleCard = ({
@@ -24,6 +27,8 @@ export const VuiSimpleCard = ({
   onClick,
   error,
   warning,
+  isLoading,
+  loadingIndicator,
   ...rest
 }: Props) => {
   const { createLink } = useVuiContext();
@@ -35,7 +40,8 @@ export const VuiSimpleCard = ({
       "vuiSimpleCard--interactive": href || onClick,
       "vuiSimpleCard--fullHeight": fullHeight,
       "vuiSimpleCard--danger": error,
-      "vuiSimpleCard--warning": warning
+      "vuiSimpleCard--warning": warning,
+      "vuiSimpleCard--loading": isLoading
     },
     className
   );
@@ -43,6 +49,7 @@ export const VuiSimpleCard = ({
   const content = (
     <>
       {children}
+      {isLoading && (loadingIndicator ?? <VuiLoadingBar />)}
       {error && (
         <>
           <VuiSpacer size="s" />
@@ -64,20 +71,21 @@ export const VuiSimpleCard = ({
       href,
       onClick,
       children: content,
+      "aria-busy": isLoading,
       ...rest
     });
   }
 
   if (onClick) {
     return (
-      <button className={classes} onClick={onClick} {...rest}>
+      <button className={classes} onClick={onClick} aria-busy={isLoading} {...rest}>
         {content}
       </button>
     );
   }
 
   return (
-    <div className={classes} onClick={onClick} {...rest}>
+    <div className={classes} onClick={onClick} aria-busy={isLoading} {...rest}>
       {content}
     </div>
   );

--- a/src/lib/components/card/_index.scss
+++ b/src/lib/components/card/_index.scss
@@ -190,6 +190,11 @@
   height: 100%;
 }
 
+.vuiSimpleCard--loading {
+  position: relative;
+  overflow: hidden;
+}
+
 .vuiSimpleCard--s {
   padding: $sizeS;
 }

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -84,6 +84,7 @@ import { KvTableItem, KvTableItems, KvTablePadding, KvTableAlign } from "./kvTab
 import { VuiLink, VuiLinkInternal } from "./link/Link";
 import { LinkProps } from "./link/types";
 import { VuiList } from "./list/List";
+import { LOADING_BAR_COLOR, VuiLoadingBar } from "./loadingBar/LoadingBar";
 import { VuiMenu } from "./menu/Menu";
 import { VuiMenuItem, MenuItem } from "./menu/MenuItem";
 import { VuiMenuList } from "./menuList/VuiMenuList";
@@ -210,6 +211,7 @@ export {
   ICON_COLOR,
   ICON_SIZE,
   ICON_TYPE,
+  LOADING_BAR_COLOR,
   PATCH_COLOR,
   PROGRESS_BAR_COLOR,
   SPACER_SIZE,
@@ -283,6 +285,7 @@ export {
   VuiLink,
   VuiLinkInternal,
   VuiList,
+  VuiLoadingBar,
   VuiMenu,
   VuiMenuItem,
   VuiMenuList,

--- a/src/lib/components/link/types.ts
+++ b/src/lib/components/link/types.ts
@@ -17,6 +17,7 @@ export type LinkProps = {
   isAnchor?: boolean;
   tabIndex?: number;
   "data-testid"?: string;
+  "aria-busy"?: boolean;
   ref?: ForwardedRef<HTMLAnchorElement | null>;
   download?: string;
 };

--- a/src/lib/components/loadingBar/LoadingBar.tsx
+++ b/src/lib/components/loadingBar/LoadingBar.tsx
@@ -1,0 +1,16 @@
+import classNames from "classnames";
+
+export const LOADING_BAR_COLOR = ["accent", "primary", "danger", "warning", "success", "neutral", "subdued"] as const;
+
+type Props = {
+  color?: (typeof LOADING_BAR_COLOR)[number];
+  className?: string;
+};
+
+// An indeterminate activity indicator that anchors to the bottom edge of its
+// nearest positioned ancestor. Useful for signaling background activity inside
+// containers such as cards without disturbing their content.
+export const VuiLoadingBar = ({ color = "primary", className, ...rest }: Props) => {
+  const classes = classNames("vuiLoadingBar", `vuiLoadingBar--${color}`, className);
+  return <div className={classes} role="progressbar" aria-label="Loading" {...rest} />;
+};

--- a/src/lib/components/loadingBar/_index.scss
+++ b/src/lib/components/loadingBar/_index.scss
@@ -1,0 +1,68 @@
+@use "sass:map";
+
+.vuiLoadingBar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: $sizeXxxs;
+  overflow: hidden;
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
+
+  // The sweeping segment.
+  &::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 40%;
+    animation: vuiLoadingBarSweep 1.5s ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      animation: vuiLoadingBarPulse 2s ease-in-out infinite;
+      width: 100%;
+    }
+  }
+}
+
+@keyframes vuiLoadingBarSweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(250%);
+  }
+}
+
+@keyframes vuiLoadingBarPulse {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+// Color
+$color: (
+  accent: var(--vui-color-accent-shade),
+  primary: var(--vui-color-primary-shade),
+  success: var(--vui-color-success-shade),
+  warning: var(--vui-color-warning-shade),
+  danger: var(--vui-color-danger-shade),
+  neutral: var(--vui-color-dark-shade),
+  subdued: var(--vui-color-subdued-shade)
+);
+
+@each $colorName, $colorValue in $color {
+  .vuiLoadingBar--#{$colorName} {
+    &::after {
+      background: linear-gradient(90deg, transparent, #{$colorValue});
+    }
+  }
+}

--- a/src/lib/components/table/Table.tsx
+++ b/src/lib/components/table/Table.tsx
@@ -45,6 +45,7 @@ type Props<T> = {
   search?: Search;
   activeRowId?: string;
   customControls?: React.ReactNode;
+  statusIndicator?: React.ReactNode;
   onSort?: OnSort;
   onReload?: () => void;
   content?: React.ReactNode;
@@ -92,6 +93,7 @@ export const VuiTable = <T extends Row>({
   search,
   activeRowId,
   customControls,
+  statusIndicator,
   onSort,
   onReload,
   content,
@@ -343,6 +345,7 @@ export const VuiTable = <T extends Row>({
       {(hasSearch ||
         customControls ||
         (hasBulkActions && selectedRows && selectedRows.length > 0) ||
+        Boolean(statusIndicator) ||
         Boolean(onReload)) && (
         <>
           <VuiFlexContainer
@@ -379,13 +382,19 @@ export const VuiTable = <T extends Row>({
               </VuiFlexItem>
             )}
 
-            {/* Reload */}
-            {onReload && (
+            {/* Status indicator and reload */}
+            {(statusIndicator || onReload) && (
               <VuiFlexItem grow={1} shrink={false}>
-                <VuiFlexContainer justifyContent="end">
-                  <VuiButtonSecondary color="neutral" onClick={() => onReload()} data-testid={reloadTestId}>
-                    Reload
-                  </VuiButtonSecondary>
+                <VuiFlexContainer justifyContent="end" alignItems="center" spacing="s">
+                  {statusIndicator && <VuiFlexItem grow={false}>{statusIndicator}</VuiFlexItem>}
+
+                  {onReload && (
+                    <VuiFlexItem grow={false}>
+                      <VuiButtonSecondary color="neutral" onClick={() => onReload()} data-testid={reloadTestId}>
+                        Reload
+                      </VuiButtonSecondary>
+                    </VuiFlexItem>
+                  )}
                 </VuiFlexContainer>
               </VuiFlexItem>
             )}

--- a/src/lib/styles/styles.scss
+++ b/src/lib/styles/styles.scss
@@ -32,6 +32,7 @@
 @import "../components/kvTable/index";
 @import "../components/link/index";
 @import "../components/list/index";
+@import "../components/loadingBar/index";
 @import "../components/menu/index";
 @import "../components/menuList/index";
 @import "../components/modal/index";


### PR DESCRIPTION
# feat: extend progress indicators for `VuiSimpleCard` and `VuiTable`

### Summary

The existing loading states are not ideal for long-running operations that provide incremental updates (e.g. streamed or stream-like REST responses). This PR introduces reusable progress indicators that provide continuous visual feedback without blocking the UI.

### Changes made
1. A reusable loading bar component that attaches to the bottom border of its parent container

https://github.com/user-attachments/assets/ee43b7fe-32cc-41a2-b1b3-7fbe311011b9

2. Extends loading state to `VuiSimpleCard`

https://github.com/user-attachments/assets/5df601de-3967-4085-859b-ca4de2397a04

3 Adds a `statusIndicator` prop to the `VuiTable` for rendering custom status content.

<img width="1199" height="342" alt="image" src="https://github.com/user-attachments/assets/d7701554-16df-40a2-ad9e-03a8a33abbd0" />
