### PR TITLE
Allow manually dispatching the publish workflow

### DIFF
--- a/.github/workflows/publish-on-version-change.yml
+++ b/.github/workflows/publish-on-version-change.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   # Allows GitHub Actions to generate OIDC token.
@@ -13,6 +14,9 @@ permissions:
 jobs:
   check-version-change:
     name: check-version-change
+    # version-check reads the push event's commits, so it only runs on push;
+    # a manual dispatch publishes unconditionally.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       did-version-change: ${{ steps.check.outputs.changed }}
@@ -33,7 +37,10 @@ jobs:
     name: publish-to-npm
     runs-on: ubuntu-latest
     needs: [check-version-change]
-    if: needs.check-version-change.outputs.did-version-change == 'true'
+    if: >-
+      !cancelled() &&
+      (github.event_name == 'workflow_dispatch' ||
+       needs.check-version-change.outputs.did-version-change == 'true')
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The `publish-to-npm` job only runs when a push to main includes a version change. When that run fails (as it did for 20.4.0, when `npm@latest` jumped to v12 and dropped Node 20 support), there's no way to retry without a dummy version bump — re-running the failed workflow uses the old workflow file from that commit.

This adds a `workflow_dispatch` trigger as a manual escape hatch:

- `check-version-change` is gated to `push` events (`EndBug/version-check` reads the push payload's commits).
- `publish-to-npm` runs on dispatch unconditionally, via `!cancelled()` so the skipped check job doesn't block it. On push, behavior is unchanged: a failed or negative version check still blocks publishing.

After merging, publishing 20.4.0 is: `gh workflow run publish-on-version-change.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qp1HyDL4sU18JrpqFHr97e