### PR TITLE
Bump to 22.3.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "22.0.0",
+  "version": "22.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vectara/vectara-ui",
-      "version": "22.0.0",
+      "version": "22.3.0",
       "dependencies": {
         "@types/jest": "^27.5.2",
         "@types/mdx": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vectara/vectara-ui",
-  "version": "22.2.0",
+  "version": "22.3.0",
   "homepage": "./",
   "description": "Vectara's design system, codified as a React and Sass component library",
   "author": "Vectara",


### PR DESCRIPTION
Version bump for the markdown viewer work merged in #456.

`22.2.0` → `22.3.0` (minor — additive only):

- `VuiMarkdown` — markdown viewer
- `VuiMarkdownPreviewModal` — large-screen preview
- `VuiTabs` — new `tabListProps` / `tabListRef` props
- `VuiTab` — `id` / `role` / `tabIndex` / `aria-*` passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFQjHrHTnL5TQ2NZBmZNGK